### PR TITLE
feat: Add pattern matching with match expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,36 @@ Type 'exit' or press Ctrl+C to quit
 (11 21 31): List<i32>
 ```
 
+### パターンマッチング
+`match` 式でスカラーやリストを構造分解できます。対応パターン:
+
+- リテラル (`1`, `true`, `"foo"` など) — 値が等しいときにマッチ
+- `_` — ワイルドカード（何にでもマッチし、束縛しない）
+- 変数名 — 何にでもマッチし、その名前で束縛
+- `nil` — 空リスト (`nil` または `(list)`) にマッチ
+- `(cons head tail)` — 非空リストを先頭と残りに分解（入れ子可）
+
+```lisp
+> (match 1 (1 "one") (2 "two") (_ "other"))
+"one": String
+
+; head/tail への束縛
+> (match (list 10 20 30) ((cons h t) h) (nil 0))
+10: i32
+
+; 入れ子パターン: 先頭が 1 のリストだけマッチ
+> (match (list 1 2 3) ((cons 1 _) "starts-with-one") (_ "other"))
+"starts-with-one": String
+
+; リスト総和を再帰 + match で
+> (defn sum [xs: _] -> i32
+    (match xs
+      (nil 0)
+      ((cons h t) (+ h (sum t)))))
+> (sum (list 1 2 3 4 5))
+15: i32
+```
+
 ## プロジェクト構造
 
 ```
@@ -261,7 +291,7 @@ Error: 99999999999999999999 is out of i32 range
 ### Phase 2 (中期)
 - [x] リスト型 (`List<T>`) と基本操作
 - [x] 高階関数 (`map`, `filter`, `fold`)
-- [ ] パターンマッチング
+- [x] パターンマッチング (リテラル/変数/ワイルドカード/`nil`/`cons`)
 - [ ] 構造体とレコード型
 - [ ] モジュールシステム
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -35,7 +35,30 @@ pub enum Expr {
         func: Box<Expr>,
         args: Vec<Expr>,
     },
+    Match {
+        scrutinee: Box<Expr>,
+        arms: Vec<(Pattern, Expr)>,
+    },
     Nil,               // Empty list / nil
+}
+
+/// Patterns recognized by `match`.
+///
+/// Minimum set for this iteration: literals, wildcard, variable binding,
+/// `nil`, and `(cons head tail)` for list decomposition. Nested patterns
+/// (e.g. `(cons 0 rest)`) are supported because the head/tail fields are
+/// themselves Patterns.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Pattern {
+    Wildcard,                               // _
+    Variable(String),                       // x — binds anything
+    LiteralI32(i32),
+    LiteralI64(i64),
+    LiteralF64(f64),
+    LiteralBool(bool),
+    LiteralString(String),
+    Nil,                                    // nil / ()
+    Cons(Box<Pattern>, Box<Pattern>),       // (cons head tail)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -145,7 +168,30 @@ impl fmt::Display for Expr {
                 }
                 write!(f, ")")
             }
+            Expr::Match { scrutinee, arms } => {
+                write!(f, "(match {}", scrutinee)?;
+                for (pat, body) in arms {
+                    write!(f, " ({} {})", pat, body)?;
+                }
+                write!(f, ")")
+            }
             Expr::Nil => write!(f, "nil"),
+        }
+    }
+}
+
+impl fmt::Display for Pattern {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Pattern::Wildcard => write!(f, "_"),
+            Pattern::Variable(name) => write!(f, "{}", name),
+            Pattern::LiteralI32(n) => write!(f, "{}", n),
+            Pattern::LiteralI64(n) => write!(f, "{}", n),
+            Pattern::LiteralF64(n) => write!(f, "{}", n),
+            Pattern::LiteralBool(b) => write!(f, "{}", b),
+            Pattern::LiteralString(s) => write!(f, "\"{}\"", s),
+            Pattern::Nil => write!(f, "nil"),
+            Pattern::Cons(head, tail) => write!(f, "(cons {} {})", head, tail),
         }
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,4 +1,4 @@
-use crate::ast::Expr;
+use crate::ast::{Expr, Pattern};
 use crate::env::{Environment, Value};
 
 pub fn eval(expr: &Expr, env: &mut Environment) -> Result<Value, String> {
@@ -66,6 +66,17 @@ pub fn eval(expr: &Expr, env: &mut Environment) -> Result<Value, String> {
             })
         }
         
+        Expr::Match { scrutinee, arms } => {
+            let value = eval(scrutinee, env)?;
+            for (pat, body) in arms {
+                let mut new_env = env.extend();
+                if pattern_match(pat, &value, &mut new_env) {
+                    return eval(body, &mut new_env);
+                }
+            }
+            Err(format!("No match arm matched value: {}", value))
+        }
+
         Expr::Call { func, args } => {
             let func_val = eval(func, env)?;
             let arg_vals: Result<Vec<_>, _> = args.iter().map(|a| eval(a, env)).collect();
@@ -201,6 +212,36 @@ pub fn eval(expr: &Expr, env: &mut Environment) -> Result<Value, String> {
                 }, env)
             }
         }
+    }
+}
+
+/// Try to match `value` against `pattern`, binding any captured variables
+/// into `env`. Returns true on success. On failure the caller should
+/// discard `env` (bindings already written are considered scratch).
+fn pattern_match(pattern: &Pattern, value: &Value, env: &mut Environment) -> bool {
+    match (pattern, value) {
+        (Pattern::Wildcard, _) => true,
+        (Pattern::Variable(name), v) => {
+            env.set(name.clone(), v.clone());
+            true
+        }
+        (Pattern::LiteralI32(a), Value::Integer32(b)) => a == b,
+        (Pattern::LiteralI64(a), Value::Integer64(b)) => a == b,
+        (Pattern::LiteralF64(a), Value::Float(b)) => a == b,
+        (Pattern::LiteralBool(a), Value::Bool(b)) => a == b,
+        (Pattern::LiteralString(a), Value::String(b)) => a == b,
+        (Pattern::Nil, Value::Nil) => true,
+        (Pattern::Nil, Value::List(items)) => items.is_empty(),
+        (Pattern::Cons(head_pat, tail_pat), Value::List(items)) if !items.is_empty() => {
+            let head = items[0].clone();
+            let tail = if items.len() == 1 {
+                Value::Nil
+            } else {
+                Value::List(items[1..].to_vec())
+            };
+            pattern_match(head_pat, &head, env) && pattern_match(tail_pat, &tail, env)
+        }
+        _ => false,
     }
 }
 

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -3,7 +3,7 @@ use crate::parser::types::parse_type_annotation;
 use nom::{
     branch::alt,
     bytes::complete::{escaped, tag, take_while1},
-    character::complete::{char, digit1, multispace0, none_of},
+    character::complete::{char, digit1, multispace0, multispace1, none_of},
     combinator::{map, opt, recognize, value},
     multi::many0,
     sequence::{delimited, preceded, tuple},
@@ -133,6 +133,7 @@ fn parse_list(input: &str) -> IResult<&str, Expr, crate::parser::error::ParseErr
                 Expr::Symbol(s) if s == "let" => parse_let_expr(input),
                 Expr::Symbol(s) if s == "defn" => parse_defn_expr(input),
                 Expr::Symbol(s) if s == "fn" || s == "lambda" => parse_lambda_expr(input),
+                Expr::Symbol(s) if s == "match" => parse_match_expr(input),
                 _ => {
                     let (input, _) = multispace0(input)?;
                     let (input, rest) = many0(preceded(multispace0, parse_expr))(input)?;
@@ -313,6 +314,104 @@ fn parse_symbol_name(input: &str) -> IResult<&str, String, crate::parser::error:
     let (input, s) = take_while1(|c: char| {
         c.is_alphanumeric() || "_-".contains(c)
     })(input)?;
-    
+
     Ok((input, s.to_string()))
+}
+
+// === Pattern matching ===
+
+/// Parse `(match <expr> (<pat> <body>) ...)`.
+/// Caller has already consumed the leading `(` and the `match` keyword.
+fn parse_match_expr(input: &str) -> IResult<&str, Expr, crate::parser::error::ParseError> {
+    let (input, _) = multispace0(input)?;
+    let (input, scrutinee) = parse_expr(input)?;
+
+    // One or more arms, each a `(pattern body)` S-expression.
+    let (input, arms) = many0(preceded(multispace0, parse_match_arm))(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, _) = char(')')(input)?;
+
+    if arms.is_empty() {
+        return Err(nom::Err::Failure(
+            crate::parser::error::ParseError::UnexpectedInput(
+                "match requires at least one arm".to_string(),
+            ),
+        ));
+    }
+
+    Ok((
+        input,
+        Expr::Match {
+            scrutinee: Box::new(scrutinee),
+            arms,
+        },
+    ))
+}
+
+fn parse_match_arm(
+    input: &str,
+) -> IResult<&str, (crate::ast::Pattern, Expr), crate::parser::error::ParseError> {
+    let (input, _) = char('(')(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, pat) = parse_pattern(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, body) = parse_expr(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, _) = char(')')(input)?;
+    Ok((input, (pat, body)))
+}
+
+fn parse_pattern(
+    input: &str,
+) -> IResult<&str, crate::ast::Pattern, crate::parser::error::ParseError> {
+    let (input, _) = multispace0(input)?;
+    alt((parse_cons_pattern, parse_atom_pattern))(input)
+}
+
+/// `(cons <head-pat> <tail-pat>)` — nested patterns supported.
+fn parse_cons_pattern(
+    input: &str,
+) -> IResult<&str, crate::ast::Pattern, crate::parser::error::ParseError> {
+    let (input, _) = char('(')(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, _) = tag("cons")(input)?;
+    let (input, _) = multispace1(input)?;
+    let (input, head) = parse_pattern(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, tail) = parse_pattern(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, _) = char(')')(input)?;
+    Ok((
+        input,
+        crate::ast::Pattern::Cons(Box::new(head), Box::new(tail)),
+    ))
+}
+
+/// Atom-level pattern: literals, wildcard, nil, or variable binding.
+///
+/// We reuse the expression parsers for literals — they won't commit to a
+/// list context because atoms don't start with `(`.
+fn parse_atom_pattern(
+    input: &str,
+) -> IResult<&str, crate::ast::Pattern, crate::parser::error::ParseError> {
+    let (input, e) = parse_atom(input)?;
+    let pat = match e {
+        Expr::Bool(b) => crate::ast::Pattern::LiteralBool(b),
+        Expr::Integer32(n) => crate::ast::Pattern::LiteralI32(n),
+        Expr::Integer64(n) => crate::ast::Pattern::LiteralI64(n),
+        Expr::Float(n) => crate::ast::Pattern::LiteralF64(n),
+        Expr::String(s) => crate::ast::Pattern::LiteralString(s),
+        Expr::Nil => crate::ast::Pattern::Nil,
+        Expr::Symbol(s) if s == "_" => crate::ast::Pattern::Wildcard,
+        Expr::Symbol(s) => crate::ast::Pattern::Variable(s),
+        other => {
+            return Err(nom::Err::Failure(
+                crate::parser::error::ParseError::UnexpectedInput(format!(
+                    "not a valid atom pattern: {}",
+                    other
+                )),
+            ));
+        }
+    };
+    Ok((input, pat))
 }

--- a/src/tests/eval_tests.rs
+++ b/src/tests/eval_tests.rs
@@ -904,4 +904,150 @@ mod tests {
         );
         assert!(result.is_err());
     }
+
+    // ======================================================================
+    // Pattern matching
+    // ======================================================================
+
+    #[test]
+    fn test_eval_match_literal() {
+        let result = eval_str("(match 1 (1 \"one\") (2 \"two\") (_ \"other\"))").unwrap();
+        match result {
+            Value::String(s) => assert_eq!(s, "one"),
+            _ => panic!("Expected String"),
+        }
+    }
+
+    #[test]
+    fn test_eval_match_wildcard_fallthrough() {
+        let result = eval_str("(match 99 (1 \"one\") (_ \"other\"))").unwrap();
+        match result {
+            Value::String(s) => assert_eq!(s, "other"),
+            _ => panic!("Expected String"),
+        }
+    }
+
+    #[test]
+    fn test_eval_match_variable_binding() {
+        // Variable patterns bind the scrutinee; first arm always matches.
+        let result = eval_str("(match 42 (x (+ x 1)))").unwrap();
+        assert!(matches!(result, Value::Integer32(43)));
+    }
+
+    #[test]
+    fn test_eval_match_nil_on_empty_list() {
+        let result = eval_str("(match nil (nil \"empty\") (_ \"nonempty\"))").unwrap();
+        match result {
+            Value::String(s) => assert_eq!(s, "empty"),
+            _ => panic!("Expected String"),
+        }
+    }
+
+    #[test]
+    fn test_eval_match_nil_on_list_literal() {
+        // (list) produces an empty list; nil pattern should match it.
+        let result =
+            eval_str("(match (list) (nil \"empty\") (_ \"nonempty\"))").unwrap();
+        match result {
+            Value::String(s) => assert_eq!(s, "empty"),
+            _ => panic!("Expected String"),
+        }
+    }
+
+    #[test]
+    fn test_eval_match_cons_pattern() {
+        // Decompose list into head and tail; bind both.
+        let result =
+            eval_str("(match (list 1 2 3) ((cons h t) h) (nil 0))").unwrap();
+        assert!(matches!(result, Value::Integer32(1)));
+    }
+
+    #[test]
+    fn test_eval_match_cons_nested() {
+        // Pattern (cons 1 _) only matches lists starting with 1.
+        let result = eval_str(
+            "(match (list 1 2 3) ((cons 1 _) \"starts-with-one\") (_ \"other\"))",
+        )
+        .unwrap();
+        match result {
+            Value::String(s) => assert_eq!(s, "starts-with-one"),
+            _ => panic!("Expected String"),
+        }
+
+        let result = eval_str(
+            "(match (list 2 3) ((cons 1 _) \"starts-with-one\") (_ \"other\"))",
+        )
+        .unwrap();
+        match result {
+            Value::String(s) => assert_eq!(s, "other"),
+            _ => panic!("Expected String"),
+        }
+    }
+
+    #[test]
+    fn test_eval_match_no_arm_matches_error() {
+        // No wildcard arm, value doesn't match any literal.
+        let result = eval_str("(match 5 (1 \"one\") (2 \"two\"))");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_eval_match_recursive_sum() {
+        // Sum a list via recursion + match.
+        let program = "(defn sum [xs: _] -> i32 \
+             (match xs \
+               (nil 0) \
+               ((cons h t) (+ h (sum t)))))";
+        let expr = parser::parse(program).map_err(|e| e.to_string()).unwrap();
+        let mut env = Environment::new();
+        eval(&expr, &mut env).unwrap();
+
+        let call = parser::parse("(sum (list 1 2 3 4 5))")
+            .map_err(|e| e.to_string())
+            .unwrap();
+        let result = eval(&call, &mut env).unwrap();
+        assert!(matches!(result, Value::Integer32(15)));
+    }
+
+    #[test]
+    fn test_type_check_match_literal() {
+        let ty = type_check_str("(match 1 (1 \"one\") (_ \"other\"))").unwrap();
+        assert_eq!(ty, Type::String);
+    }
+
+    #[test]
+    fn test_type_check_match_variable_binding() {
+        // `x` is bound to the scrutinee's type (i32), so (+ x 1) type-checks.
+        let ty = type_check_str("(match 42 (x (+ x 1)))").unwrap();
+        assert_eq!(ty, Type::I32);
+    }
+
+    #[test]
+    fn test_type_check_match_cons_binding() {
+        // In (cons h t), h has the list's element type, t has the list type.
+        let ty = type_check_str("(match (list 1 2 3) ((cons h _) h) (nil 0))").unwrap();
+        assert_eq!(ty, Type::I32);
+    }
+
+    #[test]
+    fn test_type_check_match_arms_must_agree() {
+        // Arms return String and i32 — should error.
+        let result = type_check_str("(match 1 (1 \"one\") (_ 2))");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("same type"));
+    }
+
+    #[test]
+    fn test_type_check_match_literal_type_mismatch() {
+        // Scrutinee is i32 but pattern is a bool literal.
+        let result = type_check_str("(match 1 (true 0) (_ 1))");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_type_check_match_cons_requires_list() {
+        // Scrutinee is an i32; cons pattern is a list-only pattern.
+        let result = type_check_str("(match 1 ((cons h t) h) (_ 0))");
+        assert!(result.is_err());
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Expr, Type};
+use crate::ast::{Expr, Pattern, Type};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -257,6 +257,35 @@ pub fn type_check(expr: &Expr, env: &mut TypeEnv) -> Result<Type, String> {
             })
         }
         
+        Expr::Match { scrutinee, arms } => {
+            let scrutinee_type = type_check(scrutinee, env)?;
+
+            // Validate each arm. Bindings introduced by the pattern are
+            // visible only in that arm's body — we clone the env so
+            // sibling arms don't see them.
+            let mut result_type: Option<Type> = None;
+            for (pat, body) in arms {
+                check_pattern(pat, &scrutinee_type)?;
+                let mut arm_env = env.extend();
+                bind_pattern(pat, &scrutinee_type, &mut arm_env);
+                let body_type = type_check(body, &mut arm_env)?;
+                match &result_type {
+                    None => result_type = Some(body_type),
+                    Some(expected) => {
+                        if !types_match(expected, &body_type) {
+                            return Err(format!(
+                                "match arms must have the same type: {} vs {}",
+                                expected, body_type
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // Parser guarantees at least one arm, but be defensive.
+            result_type.ok_or_else(|| "match has no arms".to_string())
+        }
+
         Expr::Call { func, args } => {
             let func_type = type_check(func, env)?;
             
@@ -554,6 +583,95 @@ fn expect_function(ty: &Type, op: &str) -> Result<(Vec<Type>, Type), String> {
     match ty {
         Type::Function { params, return_type } => Ok((params.clone(), *return_type.clone())),
         _ => Err(format!("{} expects a function, got {}", op, ty)),
+    }
+}
+
+/// Validate that `pattern` is compatible with `scrutinee` type.
+///
+/// Wildcards and variables match anything. Literal patterns must match
+/// their primitive type. `nil` and `cons` require the scrutinee to be
+/// a list type (or Inferred).
+fn check_pattern(pattern: &Pattern, scrutinee: &Type) -> Result<(), String> {
+    match pattern {
+        Pattern::Wildcard | Pattern::Variable(_) => Ok(()),
+        Pattern::LiteralI32(_) => {
+            if types_match(scrutinee, &Type::I32) {
+                Ok(())
+            } else {
+                Err(format!("pattern i32 does not match scrutinee type {}", scrutinee))
+            }
+        }
+        Pattern::LiteralI64(_) => {
+            if types_match(scrutinee, &Type::I64) {
+                Ok(())
+            } else {
+                Err(format!("pattern i64 does not match scrutinee type {}", scrutinee))
+            }
+        }
+        Pattern::LiteralF64(_) => {
+            if types_match(scrutinee, &Type::F64) {
+                Ok(())
+            } else {
+                Err(format!("pattern f64 does not match scrutinee type {}", scrutinee))
+            }
+        }
+        Pattern::LiteralBool(_) => {
+            if types_match(scrutinee, &Type::Bool) {
+                Ok(())
+            } else {
+                Err(format!("pattern bool does not match scrutinee type {}", scrutinee))
+            }
+        }
+        Pattern::LiteralString(_) => {
+            if types_match(scrutinee, &Type::String) {
+                Ok(())
+            } else {
+                Err(format!("pattern String does not match scrutinee type {}", scrutinee))
+            }
+        }
+        Pattern::Nil => match scrutinee {
+            Type::List(_) | Type::Inferred => Ok(()),
+            _ => Err(format!("nil pattern requires a list, got {}", scrutinee)),
+        },
+        Pattern::Cons(head, tail) => match scrutinee {
+            Type::List(elem) => {
+                check_pattern(head, elem)?;
+                check_pattern(tail, scrutinee)?;
+                Ok(())
+            }
+            Type::Inferred => {
+                check_pattern(head, &Type::Inferred)?;
+                check_pattern(tail, &Type::Inferred)?;
+                Ok(())
+            }
+            _ => Err(format!("cons pattern requires a list, got {}", scrutinee)),
+        },
+    }
+}
+
+/// Bind any variables introduced by `pattern` into `env` with appropriate
+/// types derived from `scrutinee`. Caller is responsible for scoping
+/// (typically via `env.extend()`).
+fn bind_pattern(pattern: &Pattern, scrutinee: &Type, env: &mut TypeEnv) {
+    match pattern {
+        Pattern::Wildcard
+        | Pattern::LiteralI32(_)
+        | Pattern::LiteralI64(_)
+        | Pattern::LiteralF64(_)
+        | Pattern::LiteralBool(_)
+        | Pattern::LiteralString(_)
+        | Pattern::Nil => {}
+        Pattern::Variable(name) => {
+            env.insert(name.clone(), scrutinee.clone());
+        }
+        Pattern::Cons(head, tail) => {
+            let (head_ty, tail_ty) = match scrutinee {
+                Type::List(elem) => (*elem.clone(), scrutinee.clone()),
+                _ => (Type::Inferred, Type::List(Box::new(Type::Inferred))),
+            };
+            bind_pattern(head, &head_ty, env);
+            bind_pattern(tail, &tail_ty, env);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- `match` 式を追加。対応パターンはリテラル / ワイルドカード (`_`) / 変数束縛 / `nil` / `(cons head tail)`（入れ子可）
- 型チェッカでパターンとスクルーティニ型の整合性を検証し、全アームの戻り値型が一致することを強制
- パターンで導入された変数はアームごとにスコープされる（型環境 / 値環境の両方）

## Implementation notes
- `src/ast.rs`: `Pattern` enum と `Expr::Match` を追加
- `src/parser/expr.rs`: `match` キーワードのパース、`parse_pattern` / `parse_cons_pattern` / `parse_atom_pattern`
- `src/eval.rs`: `Expr::Match` アームと `pattern_match` ヘルパー。`Pattern::Nil` は `Value::Nil` と空の `Value::List` の両方にマッチ
- `src/types.rs`: `check_pattern`（型整合性）と `bind_pattern`（変数の型環境登録）を追加
- README にパターンマッチングの構文例と Phase 2 チェックリスト更新

## Follow-ups (issues)
- #2 exhaustiveness checking
- #3 match guards (when 句)
- #4 struct / record patterns
- #5 追加の入れ子パターン (`(list ...)` / or / as)

## Test plan
- [x] \`cargo test\` — 81 件すべてパス（新規 15 件）
- [x] \`cargo clippy -- -D warnings\` — warnings なし
- [x] REPL で再帰 + match のリスト総和が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)