### PR TITLE
feat: Add (list ...) and (as ...) match patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Type 'exit' or press Ctrl+C to quit
 - 変数名 — 何にでもマッチし、その名前で束縛
 - `nil` — 空リスト (`nil` または `(list)`) にマッチ
 - `(cons head tail)` — 非空リストを先頭と残りに分解（入れ子可）
+- `(list p1 p2 ...)` — ちょうどN要素のリストに位置でマッチ（`cons` 連鎖の糖衣）
+- `(as <pat> <name>)` — `<pat>` にマッチしつつ、値全体を `<name>` でも束縛
 
 ```lisp
 > (match 1 (1 "one") (2 "two") (_ "other"))
@@ -259,6 +261,20 @@ Type 'exit' or press Ctrl+C to quit
       ((cons h t) (+ h (sum t)))))
 > (sum (list 1 2 3 4 5))
 15: i32
+
+; (list ...) パターン: 固定長のリストを位置で分解
+> (match (list 10 20 30) ((list a b c) (+ a (+ b c))) (_ 0))
+60: i32
+
+; 要素数が合わないと次のアームへフォールスルー
+> (match (list 1 2) ((list a b c) a) (_ 99))
+99: i32
+
+; (as ...) パターン: 内側にマッチしつつ全体を別名でも束縛
+> (match (list 1 2 3)
+    ((as (cons h _) xs) (+ h (length xs)))
+    (_ 0))
+4: i32
 ```
 
 ## プロジェクト構造

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -59,6 +59,10 @@ pub enum Pattern {
     LiteralString(String),
     Nil,                                    // nil / ()
     Cons(Box<Pattern>, Box<Pattern>),       // (cons head tail)
+    /// `(<pat> as name)` — match `<pat>` and additionally bind the whole
+    /// matched value to `name`. Not a sugar because the outer binding
+    /// needs the full value, not a subpart.
+    As(Box<Pattern>, String),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -192,6 +196,7 @@ impl fmt::Display for Pattern {
             Pattern::LiteralString(s) => write!(f, "\"{}\"", s),
             Pattern::Nil => write!(f, "nil"),
             Pattern::Cons(head, tail) => write!(f, "(cons {} {})", head, tail),
+            Pattern::As(inner, name) => write!(f, "({} as {})", inner, name),
         }
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -241,6 +241,12 @@ fn pattern_match(pattern: &Pattern, value: &Value, env: &mut Environment) -> boo
             };
             pattern_match(head_pat, &head, env) && pattern_match(tail_pat, &tail, env)
         }
+        // Match the inner pattern first; only bind the alias if it
+        // succeeds so failed branches don't leak the alias.
+        (Pattern::As(inner, name), v) if pattern_match(inner, v, env) => {
+            env.set(name.clone(), v.clone());
+            true
+        }
         _ => false,
     }
 }

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -365,26 +365,67 @@ fn parse_pattern(
     input: &str,
 ) -> IResult<&str, crate::ast::Pattern, crate::parser::error::ParseError> {
     let (input, _) = multispace0(input)?;
-    alt((parse_cons_pattern, parse_atom_pattern))(input)
+    alt((parse_compound_pattern, parse_atom_pattern))(input)
 }
 
-/// `(cons <head-pat> <tail-pat>)` — nested patterns supported.
-fn parse_cons_pattern(
+/// Compound, parenthesized patterns: `(cons ...)`, `(list ...)`, `(as ...)`.
+///
+/// Dispatches on the head keyword. `(list ...)` desugars to a `cons`-chain
+/// terminated by `nil`, so we don't add a new AST node for it.
+fn parse_compound_pattern(
     input: &str,
 ) -> IResult<&str, crate::ast::Pattern, crate::parser::error::ParseError> {
     let (input, _) = char('(')(input)?;
     let (input, _) = multispace0(input)?;
-    let (input, _) = tag("cons")(input)?;
-    let (input, _) = multispace1(input)?;
-    let (input, head) = parse_pattern(input)?;
-    let (input, _) = multispace0(input)?;
-    let (input, tail) = parse_pattern(input)?;
-    let (input, _) = multispace0(input)?;
-    let (input, _) = char(')')(input)?;
-    Ok((
-        input,
-        crate::ast::Pattern::Cons(Box::new(head), Box::new(tail)),
-    ))
+    let (input, head) = parse_symbol_name(input)?;
+    match head.as_str() {
+        "cons" => {
+            let (input, _) = multispace1(input)?;
+            let (input, h) = parse_pattern(input)?;
+            let (input, _) = multispace0(input)?;
+            let (input, t) = parse_pattern(input)?;
+            let (input, _) = multispace0(input)?;
+            let (input, _) = char(')')(input)?;
+            Ok((
+                input,
+                crate::ast::Pattern::Cons(Box::new(h), Box::new(t)),
+            ))
+        }
+        "list" => {
+            // Zero or more sub-patterns, then `)`.
+            let (input, items) =
+                many0(preceded(multispace0, parse_pattern))(input)?;
+            let (input, _) = multispace0(input)?;
+            let (input, _) = char(')')(input)?;
+            // Desugar: (list p1 p2 p3) => (cons p1 (cons p2 (cons p3 nil)))
+            let folded = items.into_iter().rev().fold(
+                crate::ast::Pattern::Nil,
+                |tail, head| {
+                    crate::ast::Pattern::Cons(Box::new(head), Box::new(tail))
+                },
+            );
+            Ok((input, folded))
+        }
+        "as" => {
+            // (as <pattern> <name>)
+            let (input, _) = multispace1(input)?;
+            let (input, inner) = parse_pattern(input)?;
+            let (input, _) = multispace1(input)?;
+            let (input, name) = parse_symbol_name(input)?;
+            let (input, _) = multispace0(input)?;
+            let (input, _) = char(')')(input)?;
+            Ok((
+                input,
+                crate::ast::Pattern::As(Box::new(inner), name),
+            ))
+        }
+        other => Err(nom::Err::Failure(
+            crate::parser::error::ParseError::UnexpectedInput(format!(
+                "unknown compound pattern: ({} ...)",
+                other
+            )),
+        )),
+    }
 }
 
 /// Atom-level pattern: literals, wildcard, nil, or variable binding.

--- a/src/tests/eval_tests.rs
+++ b/src/tests/eval_tests.rs
@@ -1050,4 +1050,121 @@ mod tests {
         let result = type_check_str("(match 1 ((cons h t) h) (_ 0))");
         assert!(result.is_err());
     }
+
+    // ======================================================================
+    // (list ...) pattern — desugars to cons-chain + nil
+    // ======================================================================
+
+    #[test]
+    fn test_eval_match_list_pattern_empty() {
+        let result = eval_str("(match nil ((list) \"empty\") (_ \"other\"))").unwrap();
+        match result {
+            Value::String(s) => assert_eq!(s, "empty"),
+            _ => panic!("Expected String"),
+        }
+    }
+
+    #[test]
+    fn test_eval_match_list_pattern_fixed_length() {
+        // (list a b c) matches exactly-3-element lists and binds positions.
+        let result = eval_str(
+            "(match (list 10 20 30) ((list a b c) (+ a (+ b c))) (_ -1))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::Integer32(60)));
+    }
+
+    #[test]
+    fn test_eval_match_list_pattern_length_mismatch_falls_through() {
+        // (list a b c) should NOT match a 2-element list.
+        let result = eval_str(
+            "(match (list 1 2) ((list a b c) a) (_ 99))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::Integer32(99)));
+    }
+
+    #[test]
+    fn test_eval_match_list_pattern_with_literals() {
+        // Positional literal matching.
+        let result = eval_str(
+            "(match (list 1 2 3) ((list 1 _ _) \"starts-with-one\") (_ \"other\"))",
+        )
+        .unwrap();
+        match result {
+            Value::String(s) => assert_eq!(s, "starts-with-one"),
+            _ => panic!("Expected String"),
+        }
+    }
+
+    #[test]
+    fn test_type_check_match_list_pattern_binds_elements() {
+        // (list a b) binds both to the element type (i32 here).
+        let ty = type_check_str(
+            "(match (list 1 2) ((list a b) (+ a b)) (_ 0))",
+        )
+        .unwrap();
+        assert_eq!(ty, Type::I32);
+    }
+
+    // ======================================================================
+    // (as <pattern> <name>) — alias binding
+    // ======================================================================
+
+    #[test]
+    fn test_eval_match_as_pattern_binds_whole() {
+        // `xs` gets bound to the entire matched list, not just the head.
+        let result = eval_str(
+            "(match (list 1 2 3) \
+               ((as (cons _ _) xs) (length xs)) \
+               (_ 0))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::Integer32(3)));
+    }
+
+    #[test]
+    fn test_eval_match_as_pattern_on_literal() {
+        // `n` bound to the matched value even though the inner pattern is a literal.
+        let result = eval_str(
+            "(match 42 ((as 42 n) (+ n 1)) (_ 0))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::Integer32(43)));
+    }
+
+    #[test]
+    fn test_eval_match_as_pattern_no_bind_on_failure() {
+        // When the inner pattern fails, the alias must not leak a binding
+        // into the arm. We verify by letting a later arm match and ensuring
+        // the arm we enter has no stale `n` visible (it's a fresh scope
+        // anyway, but this exercises the code path).
+        let result = eval_str(
+            "(match 99 ((as 42 n) n) (_ 0))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::Integer32(0)));
+    }
+
+    #[test]
+    fn test_type_check_match_as_pattern() {
+        // Alias type is the scrutinee type (i32), usable in the body.
+        let ty = type_check_str(
+            "(match 7 ((as _ n) (+ n 1)))",
+        )
+        .unwrap();
+        assert_eq!(ty, Type::I32);
+    }
+
+    #[test]
+    fn test_type_check_match_as_pattern_wraps_cons() {
+        // Inner cons pattern binds head; alias gets the full list type.
+        let ty = type_check_str(
+            "(match (list 1 2 3) \
+               ((as (cons h _) xs) (+ h (length xs))) \
+               (_ 0))",
+        )
+        .unwrap();
+        assert_eq!(ty, Type::I32);
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -646,6 +646,7 @@ fn check_pattern(pattern: &Pattern, scrutinee: &Type) -> Result<(), String> {
             }
             _ => Err(format!("cons pattern requires a list, got {}", scrutinee)),
         },
+        Pattern::As(inner, _) => check_pattern(inner, scrutinee),
     }
 }
 
@@ -671,6 +672,12 @@ fn bind_pattern(pattern: &Pattern, scrutinee: &Type, env: &mut TypeEnv) {
             };
             bind_pattern(head, &head_ty, env);
             bind_pattern(tail, &tail_ty, env);
+        }
+        Pattern::As(inner, name) => {
+            // Alias gets the whole scrutinee; the inner pattern adds any
+            // sub-bindings on top.
+            env.insert(name.clone(), scrutinee.clone());
+            bind_pattern(inner, scrutinee, env);
         }
     }
 }


### PR DESCRIPTION
## Summary
\`#5\` のうち 2 つを実装。\`or\` パターンは \`#8\`（双方向型推論）後に回す。

- **\`(list p1 p2 ...)\`** — 固定長リストの位置マッチ。パーサ時点で \`(cons p1 (cons p2 ... nil))\` に展開する糖衣。AST 追加なし
- **\`(as <pattern> <name>)\`** — 内側パターンにマッチさせつつ、値全体を \`<name>\` でも束縛。糖衣にできないので \`Pattern::As\` を AST に追加

## Examples

\`\`\`lisp
> (match (list 10 20 30) ((list a b c) (+ a (+ b c))) (_ 0))
60: i32

> (match (list 1 2) ((list a b c) a) (_ 99))   ; 長さ違いはフォールスルー
99: i32

> (match (list 1 2 3)
    ((as (cons h _) xs) (+ h (length xs)))     ; xs が全体に束縛
    (_ 0))
4: i32
\`\`\`

## Implementation notes

- \`src/parser/expr.rs\`: \`parse_cons_pattern\` を \`parse_compound_pattern\` に統合し、\`cons\` / \`list\` / \`as\` を head ディスパッチで処理。\`(list ...)\` は \`fold\` で \`Pattern::Cons\` 連鎖に展開
- \`src/ast.rs\`: \`Pattern::As(Box<Pattern>, String)\` を追加 + Display
- \`src/eval.rs\`: \`pattern_match\` に \`As\` アーム。失敗時に別名が漏れないよう、内側マッチが成功した場合のみ \`set\` する
- \`src/types.rs\`: \`check_pattern\` / \`bind_pattern\` に \`As\` 対応。別名の型はスクルーティニ型、内側パターンが追加で sub-binding を行う

## Why or-pattern is not here

\`(or p1 p2)\` は両枝が同じ変数を「同じ型」で束縛していることの検証が必要だが、現在の型チェッカは \`Type::Inferred\` を素通しするため、不健全な定義を許してしまう恐れがある。型推論の \`#8\` で \`Inferred\` の扱いが整理されてから入れる方が安全なので、今回は見送る。\`#5\` にコメントで残しておく予定。

## Test plan
- [x] \`cargo test\` — 99 件すべてパス（新規 10 件）
- [x] \`cargo clippy -- -D warnings\` — warnings なし
- [x] REPL で \`(list ...)\` と \`(as ...)\` の組み合わせを確認

## Follow-ups
- #5 — \`or\` パターン（\`#8\` 後）にコメント追記予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)