### PR TITLE
feat: Add (guard <pat> <expr>) match patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Type 'exit' or press Ctrl+C to quit
 - `(cons head tail)` — 非空リストを先頭と残りに分解（入れ子可）
 - `(list p1 p2 ...)` — ちょうどN要素のリストに位置でマッチ（`cons` 連鎖の糖衣）
 - `(as <pat> <name>)` — `<pat>` にマッチしつつ、値全体を `<name>` でも束縛
+- `(guard <pat> <expr>)` — `<pat>` にマッチしつつ、`<expr>`（bool）が真のときだけ成立。`<pat>` で束縛した変数は `<expr>` 内で使える
 
 ```lisp
 > (match 1 (1 "one") (2 "two") (_ "other"))
@@ -275,6 +276,19 @@ Type 'exit' or press Ctrl+C to quit
     ((as (cons h _) xs) (+ h (length xs)))
     (_ 0))
 4: i32
+
+; (guard ...) パターン: 値の条件で絞り込み
+> (defn classify [n: i32] -> String
+    (match n
+      ((guard x (> x 0)) "positive")
+      (0                 "zero")
+      (x                 "negative")))
+
+> (classify 7)
+"positive": String
+
+> (classify -3)
+"negative": String
 ```
 
 ## プロジェクト構造

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -63,6 +63,10 @@ pub enum Pattern {
     /// matched value to `name`. Not a sugar because the outer binding
     /// needs the full value, not a subpart.
     As(Box<Pattern>, String),
+    /// `(guard <pat> <expr>)` — match `<pat>` and additionally require
+    /// `<expr>` to evaluate to `true` in the env extended with `<pat>`'s
+    /// bindings. Used to express conditional pattern arms without nesting `if`.
+    Guard(Box<Pattern>, Box<Expr>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -197,6 +201,7 @@ impl fmt::Display for Pattern {
             Pattern::Nil => write!(f, "nil"),
             Pattern::Cons(head, tail) => write!(f, "(cons {} {})", head, tail),
             Pattern::As(inner, name) => write!(f, "({} as {})", inner, name),
+            Pattern::Guard(inner, expr) => write!(f, "(guard {} {})", inner, expr),
         }
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -247,6 +247,18 @@ fn pattern_match(pattern: &Pattern, value: &Value, env: &mut Environment) -> boo
             env.set(name.clone(), v.clone());
             true
         }
+        (Pattern::Guard(inner, guard_expr), v) => {
+            // Inner pattern first so its bindings are visible to the guard.
+            // If the guard returns false (or, defensively, anything else), the
+            // arm fails and the caller's per-arm env extension is discarded —
+            // see the Match arm in `eval`.
+            if !pattern_match(inner, v, env) {
+                return false;
+            }
+            // Type checker rejects non-bool guard expressions, so any other
+            // result here is treated as a failed match defensively.
+            matches!(eval(guard_expr, env), Ok(Value::Bool(true)))
+        }
         _ => false,
     }
 }

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -419,6 +419,19 @@ fn parse_compound_pattern(
                 crate::ast::Pattern::As(Box::new(inner), name),
             ))
         }
+        "guard" => {
+            // (guard <pattern> <bool-expr>)
+            let (input, _) = multispace1(input)?;
+            let (input, inner) = parse_pattern(input)?;
+            let (input, _) = multispace1(input)?;
+            let (input, guard_expr) = parse_expr(input)?;
+            let (input, _) = multispace0(input)?;
+            let (input, _) = char(')')(input)?;
+            Ok((
+                input,
+                crate::ast::Pattern::Guard(Box::new(inner), Box::new(guard_expr)),
+            ))
+        }
         other => Err(nom::Err::Failure(
             crate::parser::error::ParseError::UnexpectedInput(format!(
                 "unknown compound pattern: ({} ...)",

--- a/src/tests/eval_tests.rs
+++ b/src/tests/eval_tests.rs
@@ -1167,4 +1167,100 @@ mod tests {
         .unwrap();
         assert_eq!(ty, Type::I32);
     }
+
+    #[test]
+    fn test_eval_match_guard_passes() {
+        // Guard expression is true → arm is taken.
+        let result = eval_str(
+            "(match 5 ((guard x (> x 0)) \"pos\") (_ \"other\"))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::String(ref s) if s == "pos"));
+    }
+
+    #[test]
+    fn test_eval_match_guard_fails_falls_through() {
+        // Guard false → fall through to next arm. Bindings from the failed
+        // guard arm must not leak into the catch-all.
+        let result = eval_str(
+            "(match -3 ((guard x (> x 0)) \"pos\") (_ \"other\"))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::String(ref s) if s == "other"));
+    }
+
+    #[test]
+    fn test_eval_match_guard_with_cons_binding() {
+        // Variables bound by the inner cons pattern are visible to the guard.
+        let result = eval_str(
+            "(match (list 1 2 3) \
+               ((guard (cons h _) (> h 0)) h) \
+               (_ -1))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::Integer32(1)));
+    }
+
+    #[test]
+    fn test_eval_match_guard_under_as() {
+        // `as` inside a guard exposes both component (`x`) and whole (`whole`)
+        // bindings to the guard expression and the body.
+        let result = eval_str(
+            "(match 5 ((guard (as x whole) (> whole 0)) x) (_ -1))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::Integer32(5)));
+    }
+
+    #[test]
+    fn test_eval_match_guard_three_way() {
+        // Classic guard use case: split positive / zero / negative in one match.
+        let pos = eval_str(
+            "(match 7 \
+               ((guard x (> x 0)) \"positive\") \
+               (0 \"zero\") \
+               (_ \"negative\"))",
+        )
+        .unwrap();
+        assert!(matches!(pos, Value::String(ref s) if s == "positive"));
+
+        let zero = eval_str(
+            "(match 0 \
+               ((guard x (> x 0)) \"positive\") \
+               (0 \"zero\") \
+               (_ \"negative\"))",
+        )
+        .unwrap();
+        assert!(matches!(zero, Value::String(ref s) if s == "zero"));
+
+        let neg = eval_str(
+            "(match -7 \
+               ((guard x (> x 0)) \"positive\") \
+               (0 \"zero\") \
+               (_ \"negative\"))",
+        )
+        .unwrap();
+        assert!(matches!(neg, Value::String(ref s) if s == "negative"));
+    }
+
+    #[test]
+    fn test_type_check_match_guard_must_be_bool() {
+        // Guard expression must be Bool. `(+ x 1)` is i32, so this should
+        // be rejected by the type checker.
+        let err = type_check_str(
+            "(match 5 ((guard x (+ x 1)) \"x\") (_ \"y\"))",
+        )
+        .unwrap_err();
+        assert!(err.contains("Bool"), "expected Bool error, got: {}", err);
+    }
+
+    #[test]
+    fn test_type_check_match_guard_undefined_var() {
+        // Free variable `y` inside the guard should be reported as undefined.
+        let err = type_check_str(
+            "(match 5 ((guard x (> y 0)) \"x\") (_ \"y\"))",
+        )
+        .unwrap_err();
+        assert!(err.contains('y'), "expected undefined-var error, got: {}", err);
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -265,7 +265,7 @@ pub fn type_check(expr: &Expr, env: &mut TypeEnv) -> Result<Type, String> {
             // sibling arms don't see them.
             let mut result_type: Option<Type> = None;
             for (pat, body) in arms {
-                check_pattern(pat, &scrutinee_type)?;
+                check_pattern(pat, &scrutinee_type, env)?;
                 let mut arm_env = env.extend();
                 bind_pattern(pat, &scrutinee_type, &mut arm_env);
                 let body_type = type_check(body, &mut arm_env)?;
@@ -590,8 +590,14 @@ fn expect_function(ty: &Type, op: &str) -> Result<(Vec<Type>, Type), String> {
 ///
 /// Wildcards and variables match anything. Literal patterns must match
 /// their primitive type. `nil` and `cons` require the scrutinee to be
-/// a list type (or Inferred).
-fn check_pattern(pattern: &Pattern, scrutinee: &Type) -> Result<(), String> {
+/// a list type (or Inferred). `guard` requires its expression to be
+/// `bool` when type-checked with the inner pattern's bindings in scope —
+/// hence the `env` parameter.
+fn check_pattern(
+    pattern: &Pattern,
+    scrutinee: &Type,
+    env: &mut TypeEnv,
+) -> Result<(), String> {
     match pattern {
         Pattern::Wildcard | Pattern::Variable(_) => Ok(()),
         Pattern::LiteralI32(_) => {
@@ -635,18 +641,33 @@ fn check_pattern(pattern: &Pattern, scrutinee: &Type) -> Result<(), String> {
         },
         Pattern::Cons(head, tail) => match scrutinee {
             Type::List(elem) => {
-                check_pattern(head, elem)?;
-                check_pattern(tail, scrutinee)?;
+                check_pattern(head, elem, env)?;
+                check_pattern(tail, scrutinee, env)?;
                 Ok(())
             }
             Type::Inferred => {
-                check_pattern(head, &Type::Inferred)?;
-                check_pattern(tail, &Type::Inferred)?;
+                check_pattern(head, &Type::Inferred, env)?;
+                check_pattern(tail, &Type::Inferred, env)?;
                 Ok(())
             }
             _ => Err(format!("cons pattern requires a list, got {}", scrutinee)),
         },
-        Pattern::As(inner, _) => check_pattern(inner, scrutinee),
+        Pattern::As(inner, _) => check_pattern(inner, scrutinee, env),
+        Pattern::Guard(inner, guard_expr) => {
+            // Inner pattern must itself be valid against the scrutinee type.
+            check_pattern(inner, scrutinee, env)?;
+            // The guard expression sees the inner pattern's bindings, so
+            // type-check it in an extended env. Bindings are scoped to the
+            // guard check and the arm body (the caller already extends env
+            // for the body, so we don't pollute its env here).
+            let mut guard_env = env.extend();
+            bind_pattern(inner, scrutinee, &mut guard_env);
+            let ty = type_check(guard_expr, &mut guard_env)?;
+            if !types_match(&ty, &Type::Bool) {
+                return Err(format!("guard expression must be Bool, got {}", ty));
+            }
+            Ok(())
+        }
     }
 }
 
@@ -677,6 +698,10 @@ fn bind_pattern(pattern: &Pattern, scrutinee: &Type, env: &mut TypeEnv) {
             // Alias gets the whole scrutinee; the inner pattern adds any
             // sub-bindings on top.
             env.insert(name.clone(), scrutinee.clone());
+            bind_pattern(inner, scrutinee, env);
+        }
+        Pattern::Guard(inner, _) => {
+            // Guard expr does not introduce bindings; the inner pattern does.
             bind_pattern(inner, scrutinee, env);
         }
     }


### PR DESCRIPTION
## Summary
- `match` アームに `(guard <pat> <expr>)` パターンを追加。`<pat>` にマッチした上で `<expr>`（bool）が真のときだけアームが成立する
- 内側パターンで束縛した変数（`cons` の head/tail、`as` の別名など）はそのまま guard 式から参照できる
- ガード失敗時はアーム毎に分離された env が捨てられるので、後続アームに束縛が漏れない
- Common Lisp `trivia` ライブラリと同じ `guard` 綴りを採用（`when` は Lisp で別意味のため避けた）

Closes #3

## 書けるようになった例

```lisp
; 値の範囲で振り分け（if のネストが消える）
(defn classify [n: i32] -> String
  (match n
    ((guard x (> x 0)) "positive")
    (0                 "zero")
    (x                 "negative")))

; cons で分解した値を即座に条件に
(match (list 1 2 3)
  ((guard (cons h _) (> h 0)) h)
  (_                          -1))   ; → 1

; as と組み合わせて「分解した値」と「全体」両方を条件に
(match (list 0 9 8)
  ((guard (as (cons h t) whole)
          (and (= h 0) (> (length whole) 1)))
    t)
  (_ nil))                            ; → (9 8)
```

## 実装メモ
- `Pattern::Guard(Box<Pattern>, Box<Expr>)` を AST に追加
- パーサ: `parse_compound_pattern` に `\"guard\"` 分岐
- 評価器: `pattern_match` に Guard アーム。clippy `collapsible_match` を踏まないよう `matches!(eval(...), Ok(Value::Bool(true)))` で 1 行化
- 型チェッカ: ガード式の型検査に env が必要なので `check_pattern` のシグネチャに `&mut TypeEnv` を追加（呼び出し 6 か所を更新）。内側パターンの束縛を見える scratch env で `<expr>` を Bool として検査
- `bind_pattern` の Guard アームは内側に委譲（guard 自体は新たな束縛を導入しない）

## 意図的に含めなかったもの
- ガードのみの `(when <expr>)` 形式 → `(guard _ <expr>)` で代用可
- 1 アーム複数ガード → `(and ...)` で連結可
- 網羅性チェックとの統合 → ガードがあると判定不能になる、#2 と直交

## Test plan
- [x] 7 件のテスト追加（`test_eval_match_guard_*` ×5、`test_type_check_match_guard_*` ×2）
- [x] `cargo test`: 106 passed (99 既存 + 7 新規)
- [x] `cargo clippy -- -D warnings`: クリーン
- [x] REPL スモーク: classify / cons+guard / as+guard / describe（4 アーム）すべて期待通り

🤖 Generated with [Claude Code](https://claude.com/claude-code)