### PR TITLE
feat: Exhaustiveness checking for Bool and List<T> match

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,18 @@ Type 'exit' or press Ctrl+C to quit
 - `(as <pat> <name>)` — `<pat>` にマッチしつつ、値全体を `<name>` でも束縛
 - `(guard <pat> <expr>)` — `<pat>` にマッチしつつ、`<expr>`（bool）が真のときだけ成立。`<pat>` で束縛した変数は `<expr>` 内で使える
 
+`Bool` と `List<T>` を scrutinee にした `match` は **型チェック時に網羅性を検証** します。ケースが漏れていると不足パターンを示すエラーになります（`_` や変数で全受けすれば回避可）:
+
+```
+> (match (= 1 1) (true "yes"))
+Error: match is not exhaustive: missing patterns: false
+
+> (match (list 1 2) (nil 0))
+Error: match is not exhaustive: missing patterns: (cons _ _)
+```
+
+ガード付きアーム (`(guard ...)`) は実行時にしか真偽が決まらないため、網羅性判定の根拠にはなりません。
+
 ```lisp
 > (match 1 (1 "one") (2 "two") (_ "other"))
 "one": String

--- a/src/exhaustiveness.rs
+++ b/src/exhaustiveness.rs
@@ -1,0 +1,168 @@
+//! Exhaustiveness checking for `match` expressions.
+//!
+//! Verifies at type-check time that arms cover every possible value of the
+//! scrutinee type, for the structurally-finite types `Bool` and `List<T>`.
+//! Other types are considered exhaustive only when at least one arm is
+//! irrefutable (wildcard / variable / `(_ as name)`).
+//!
+//! Algorithm: a width-1 reduction of Maranget's usefulness algorithm.
+//! For each constructor of the scrutinee type, recurse into the sub-patterns
+//! of arms that match that constructor. Missing constructors become
+//! `Witness` values that are rendered back as `Pattern` syntax in the error
+//! message — so the user can copy-paste the missing pattern as a new arm.
+//!
+//! Guarded arms (`Pattern::Guard`) intentionally do NOT contribute to
+//! exhaustiveness: their truth value is only known at runtime, matching
+//! the Rust/OCaml posture.
+
+use crate::ast::{Pattern, Type};
+
+/// A concrete value not covered by any arm. Rendered into Pattern syntax
+/// so the user can drop it directly into the match as a new arm.
+enum Witness {
+    Wild,
+    Bool(bool),
+    Nil,
+    Cons(Box<Witness>, Box<Witness>),
+}
+
+const MAX_DEPTH: usize = 3;
+
+/// Entry point. Returns Ok if `arms` cover every value of `scrutinee`,
+/// otherwise an error listing the missing patterns.
+pub fn check(scrutinee: &Type, arms: &[&Pattern]) -> Result<(), String> {
+    let witnesses = missing(scrutinee, arms, 0);
+    if witnesses.is_empty() {
+        return Ok(());
+    }
+    let rendered: Vec<String> = witnesses.iter().map(render).collect();
+    Err(format!(
+        "match is not exhaustive: missing patterns: {}",
+        rendered.join(", ")
+    ))
+}
+
+/// Strip away outer `As` wrappers so structural inspection sees the inner
+/// pattern. `(p as name)` has the same coverage as `p`.
+fn peel_as(p: &Pattern) -> &Pattern {
+    match p {
+        Pattern::As(inner, _) => peel_as(inner),
+        other => other,
+    }
+}
+
+/// True iff this pattern matches every value of any type. Guard arms are
+/// explicitly excluded — their condition is only known at runtime.
+fn arm_is_irrefutable(p: &Pattern) -> bool {
+    matches!(peel_as(p), Pattern::Wildcard | Pattern::Variable(_))
+}
+
+/// Compute witnesses for values of `ty` not covered by `arms`.
+/// `depth` bounds the recursion into nested list types.
+fn missing(ty: &Type, arms: &[&Pattern], depth: usize) -> Vec<Witness> {
+    // An irrefutable arm covers everything at this level.
+    if arms.iter().any(|p| arm_is_irrefutable(p)) {
+        return Vec::new();
+    }
+
+    match ty {
+        Type::Bool => {
+            let mut out = Vec::new();
+            // Deterministic order: false before true.
+            for v in [false, true] {
+                if !bool_covered(v, arms) {
+                    out.push(Witness::Bool(v));
+                }
+            }
+            out
+        }
+        Type::List(elem) => {
+            let mut out = Vec::new();
+            // Deterministic order: nil before cons.
+            if !nil_covered(arms) {
+                out.push(Witness::Nil);
+            }
+            if let Some(cons_witness) = missing_cons(elem, arms, depth) {
+                out.push(cons_witness);
+            }
+            out
+        }
+        // Inferred: skip silently. Useful exhaustiveness needs concrete
+        // types, which arrive with bidirectional inference (#8).
+        Type::Inferred => Vec::new(),
+        // Infinite / opaque types: only irrefutable arms can cover them,
+        // and the early-return above already handled that case.
+        _ => vec![Witness::Wild],
+    }
+}
+
+fn bool_covered(v: bool, arms: &[&Pattern]) -> bool {
+    arms.iter().any(|p| match peel_as(p) {
+        Pattern::LiteralBool(b) => *b == v,
+        // Guard / literal mismatches / structural patterns don't cover.
+        _ => false,
+    })
+}
+
+fn nil_covered(arms: &[&Pattern]) -> bool {
+    arms.iter().any(|p| matches!(peel_as(p), Pattern::Nil))
+}
+
+/// Returns Some(witness) when there exists a cons value not covered by any
+/// arm, None when every cons value is covered. Recurses into head/tail
+/// patterns so nested structure (e.g. `List<Bool>`) is handled precisely.
+fn missing_cons(elem: &Type, arms: &[&Pattern], depth: usize) -> Option<Witness> {
+    // Collect (head, tail) pairs from cons-shaped arms. A wildcard or
+    // variable arm at this level was already handled by the irrefutable
+    // early-return in `missing`, so we don't see it here.
+    let mut head_pats: Vec<&Pattern> = Vec::new();
+    let mut tail_pats: Vec<&Pattern> = Vec::new();
+    let mut any_cons = false;
+    for p in arms {
+        if let Pattern::Cons(h, t) = peel_as(p) {
+            any_cons = true;
+            head_pats.push(h);
+            tail_pats.push(t);
+        }
+    }
+
+    if !any_cons {
+        // No cons arm at all → the entire cons constructor is missing.
+        return Some(Witness::Cons(
+            Box::new(Witness::Wild),
+            Box::new(Witness::Wild),
+        ));
+    }
+
+    // Beyond MAX_DEPTH, stop expanding — render tails as `_` to keep
+    // error messages readable.
+    if depth >= MAX_DEPTH {
+        return None;
+    }
+
+    // Recurse into the head (element type) and tail (same list type).
+    let head_witnesses = missing(elem, &head_pats, depth + 1);
+    let list_ty = Type::List(Box::new(elem.clone()));
+    let tail_witnesses = missing(&list_ty, &tail_pats, depth + 1);
+
+    // If both head and tail are fully covered, the cons case is exhaustive.
+    if head_witnesses.is_empty() && tail_witnesses.is_empty() {
+        return None;
+    }
+
+    // Pick the first head/tail witness as a representative. Showing a
+    // single concrete missing case is more actionable than enumerating
+    // the cross product.
+    let head = head_witnesses.into_iter().next().unwrap_or(Witness::Wild);
+    let tail = tail_witnesses.into_iter().next().unwrap_or(Witness::Wild);
+    Some(Witness::Cons(Box::new(head), Box::new(tail)))
+}
+
+fn render(w: &Witness) -> String {
+    match w {
+        Witness::Wild => "_".to_string(),
+        Witness::Bool(b) => b.to_string(),
+        Witness::Nil => "nil".to_string(),
+        Witness::Cons(h, t) => format!("(cons {} {})", render(h), render(t)),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod ast;
 mod env;
 mod eval;
+mod exhaustiveness;
 mod parser;
 mod types;
 

--- a/src/tests/eval_tests.rs
+++ b/src/tests/eval_tests.rs
@@ -1263,4 +1263,110 @@ mod tests {
         .unwrap_err();
         assert!(err.contains('y'), "expected undefined-var error, got: {}", err);
     }
+
+    // ======================================================================
+    // Exhaustiveness checking
+    // ======================================================================
+
+    #[test]
+    fn test_exhaustive_bool_ok() {
+        // Both true and false covered → exhaustive.
+        let ty = type_check_str("(match (= 1 1) (true 1) (false 2))").unwrap();
+        assert_eq!(ty, Type::I32);
+    }
+
+    #[test]
+    fn test_exhaustive_bool_missing_false() {
+        // Only `true` arm; `false` is missing.
+        let err = type_check_str("(match (= 1 1) (true 1))").unwrap_err();
+        assert!(
+            err.contains("not exhaustive") && err.contains("false"),
+            "expected missing-false error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_exhaustive_bool_wildcard_ok() {
+        // Wildcard covers both bool values.
+        let ty = type_check_str("(match (= 1 1) (true 1) (_ 2))").unwrap();
+        assert_eq!(ty, Type::I32);
+    }
+
+    #[test]
+    fn test_exhaustive_list_ok() {
+        // nil + (cons _ _) covers both list constructors.
+        let ty = type_check_str(
+            "(match (list 1 2) (nil 0) ((cons _ _) 1))",
+        )
+        .unwrap();
+        assert_eq!(ty, Type::I32);
+    }
+
+    #[test]
+    fn test_exhaustive_list_missing_nil() {
+        // Only cons arm; nil is missing.
+        let err = type_check_str("(match (list 1 2) ((cons _ _) 1))").unwrap_err();
+        assert!(
+            err.contains("not exhaustive") && err.contains("nil"),
+            "expected missing-nil error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_exhaustive_list_missing_cons() {
+        // Only nil arm; cons is missing.
+        let err = type_check_str("(match (list 1 2) (nil 0))").unwrap_err();
+        assert!(
+            err.contains("not exhaustive") && err.contains("cons"),
+            "expected missing-cons error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_exhaustive_nested_list_bool_partial() {
+        // List<Bool> with nil and (cons true _) — missing (cons false _).
+        let err = type_check_str(
+            "(match (list true) (nil 0) ((cons true _) 1))",
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("not exhaustive") && err.contains("cons") && err.contains("false"),
+            "expected missing (cons false _) error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_exhaustive_inferred_skipped() {
+        // When the scrutinee type is Inferred (parameter type `_`), the
+        // exhaustiveness check skips silently. This avoids false positives
+        // before bidirectional inference (#8) lands. We use a lambda with
+        // an inferred parameter type so the return type is also inferred —
+        // the only thing under test is that the non-exhaustive `match`
+        // inside does not raise an exhaustiveness error.
+        let ty = type_check_str(
+            "(fn [xs: _] (match xs ((cons _ _) 1)))",
+        )
+        .unwrap();
+        assert!(matches!(ty, Type::Function { .. }));
+    }
+
+    #[test]
+    fn test_exhaustive_guard_does_not_count() {
+        // A guarded arm cannot satisfy exhaustiveness because its truth
+        // value is only known at runtime. Even though `(guard true ...)`
+        // structurally names `true`, the arm is not considered to cover it.
+        let err = type_check_str(
+            "(match (= 1 1) ((guard true (= 1 1)) 1) (false 2))",
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("not exhaustive") && err.contains("true"),
+            "expected missing-true error (guard does not count), got: {}",
+            err
+        );
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -282,6 +282,12 @@ pub fn type_check(expr: &Expr, env: &mut TypeEnv) -> Result<Type, String> {
                 }
             }
 
+            // Exhaustiveness check after per-arm type checking, so per-arm
+            // type errors take precedence over a less-specific exhaustiveness
+            // message.
+            let arm_pats: Vec<&Pattern> = arms.iter().map(|(p, _)| p).collect();
+            crate::exhaustiveness::check(&scrutinee_type, &arm_pats)?;
+
             // Parser guarantees at least one arm, but be defensive.
             result_type.ok_or_else(|| "match has no arms".to_string())
         }


### PR DESCRIPTION
## Summary
- `match` 式の型チェック段階で **Bool と List<T> の網羅性** を検証
- 漏れているケースを Pattern 構文で列挙したエラーを返す（ユーザがそのまま arm として貼り付ければ直る）
- ガード付きアーム (`Pattern::Guard`) は網羅判定に貢献しない（Rust/OCaml と同じ）
- `Type::Inferred` の scrutinee はスキップ（#8 までの保守策、false positive 回避）

Closes #2

## 動作例

```
> (match (= 1 1) (true "yes"))
Error: match is not exhaustive: missing patterns: false

> (match (list 1 2) (nil 0))
Error: match is not exhaustive: missing patterns: (cons _ _)

> (match (list true false) (nil 0) ((cons true _) 1))
Error: match is not exhaustive: missing patterns: (cons false _)
```

ネストした `List<Bool>` でも内側まで再帰的に判定されるのがポイント。

## アルゴリズム

Maranget の usefulness アルゴリズムを **幅 1 行列に縮小した最小版**。

- 構成子有限型（Bool / List<T>）について、各構成子に対して arm の sub-pattern を集めて再帰
- ワイルドカード/変数の arm はその場で全網羅と判定
- `as` は内側に剥ぐ (`peel_as`)、Guard は明示的に non-irrefutable
- 再帰深さに `MAX_DEPTH=3` の防衛

新規モジュール `src/exhaustiveness.rs` (~155 行) に隔離。`src/types.rs` の Match arm 末尾から呼び出し。

## 設計判断（plan より抜粋）

| 論点 | 決定 | 理由 |
|---|---|---|
| 対象型 | Bool, List<T> のみ | 構成子有限型に絞れば実装が小さく価値が大きい |
| エラー文 | 不足ケースを列挙 | 貼り直しで直る、Rust/OCaml 流 |
| 到達不能アーム警告 | やらない | `Result<Type, String>` のシンプルな戻り値型を保ちたい、別 issue へ |
| Guard | 網羅貢献なし | 真偽は実行時のみ判定可 |
| As | 内側で判定 | 別名束縛のみ、構造判定に寄与しない |
| Inferred | スキップ | #8 までの保守策 |

Common Lisp `trivia` や Racket `match` は実行時警告どまりだが、Rusp は **typed Lisp** という立ち位置から OCaml/Rust 流の **ハードエラー** を採る。

## Test plan
- [x] 9 件のテスト追加（成功 3、不足検出 4、Inferred スキップ 1、Guard 不採用 1）
- [x] `cargo test`: 115 passed (106 既存 + 9 新規)
- [x] `cargo clippy --all-targets -- -D warnings`: クリーン
- [x] REPL スモーク: 全エラー文期待通り、ネスト List<Bool> も検出

## Out of scope
- 到達不能アーム警告（別 issue へ）
- i32/i64/f64/String のリテラル列挙判定（無限集合）
- struct/enum パターン (#4)
- or パターン (#5) との連携（#5 は #8 後）
- Inferred 駆動の網羅判定（#8 後に有効化される）

🤖 Generated with [Claude Code](https://claude.com/claude-code)