### PR TITLE
feat: Bidirectional type inference (段階 A) for `_` parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,26 @@ Type 'exit' or press Ctrl+C to quit
 (11 21 31): List<i32>
 ```
 
+### `_` パラメータの文脈推論 (Bidirectional Inference)
+
+トップレベルの型注釈に `_` を書いた関数パラメータは、本体内での **使われ方** を見て自動的に絞り込まれます (Rust 流の双方向型推論)。`fold` / `map` / `filter` のラムダ引数型、`length` / `car` / `cdr` / `null?` などのリスト操作、`match` の `cons` パターンが手がかりになります。
+
+```lisp
+; xs: _ は fold のラムダ第 2 引数 (i32) から List<i32> に絞られる
+> (defn sum [xs: _] -> i32
+    (fold (fn [a: i32 x: i32] -> i32 (+ a x)) 0 xs))
+#<function:1>: fn(List<i32>) -> i32
+
+> (sum (list 1 2 3 4 5))
+15: i32
+
+; length は要素型までは決められないので List<_> までの絞り込み
+> (defn len [xs: _] -> i32 (length xs))
+#<function:2>: fn(List<_>) -> i32
+```
+
+絞り込み後のシグネチャは外から見える型に反映されるので、要素型が合わない呼び出しは型エラーになります。同一パラメータが矛盾する型に絞られた場合も型エラーで検出されます。
+
 ### パターンマッチング
 `match` 式でスカラーやリストを構造分解できます。対応パターン:
 

--- a/src/tests/eval_tests.rs
+++ b/src/tests/eval_tests.rs
@@ -1340,18 +1340,20 @@ mod tests {
     }
 
     #[test]
-    fn test_exhaustive_inferred_skipped() {
-        // When the scrutinee type is Inferred (parameter type `_`), the
-        // exhaustiveness check skips silently. This avoids false positives
-        // before bidirectional inference (#8) lands. We use a lambda with
-        // an inferred parameter type so the return type is also inferred —
-        // the only thing under test is that the non-exhaustive `match`
-        // inside does not raise an exhaustiveness error.
-        let ty = type_check_str(
+    fn test_match_cons_refines_inferred_param() {
+        // 段階 A bidirectional inference: a `_` parameter used as the
+        // scrutinee of a `match` whose arms include a `cons` pattern is
+        // refined to `List<_>`. Exhaustiveness then runs and detects the
+        // missing `nil` case.
+        let err = type_check_str(
             "(fn [xs: _] (match xs ((cons _ _) 1)))",
         )
-        .unwrap();
-        assert!(matches!(ty, Type::Function { .. }));
+        .unwrap_err();
+        assert!(
+            err.contains("not exhaustive") && err.contains("nil"),
+            "expected missing nil after refinement, got: {}",
+            err
+        );
     }
 
     #[test]
@@ -1366,6 +1368,204 @@ mod tests {
         assert!(
             err.contains("not exhaustive") && err.contains("true"),
             "expected missing-true error (guard does not count), got: {}",
+            err
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Bidirectional inference (段階 A)
+    // -----------------------------------------------------------------
+
+    /// Type-check several top-level forms in sequence against a shared
+    /// `TypeEnv`. Returns the type of the last form. Mirrors the REPL
+    /// loop so tests can stage `(defn ...)` then a call site.
+    fn type_check_seq(inputs: &[&str]) -> Result<Type, String> {
+        let mut env = TypeEnv::new();
+        let mut last = Type::Inferred;
+        for input in inputs {
+            let expr = parser::parse(input).map_err(|e| e.to_string())?;
+            last = type_check(&expr, &mut env)?;
+        }
+        Ok(last)
+    }
+
+    /// Type-check + eval several top-level forms against shared envs and
+    /// return the value of the last form. Type errors short-circuit
+    /// before evaluation, mirroring the REPL.
+    fn run_seq(inputs: &[&str]) -> Result<Value, String> {
+        let mut tenv = TypeEnv::new();
+        let mut env = Environment::new();
+        let mut last_val = Value::Integer32(0);
+        for input in inputs {
+            let expr = parser::parse(input).map_err(|e| e.to_string())?;
+            type_check(&expr, &mut tenv)?;
+            last_val = eval(&expr, &mut env)?;
+        }
+        Ok(last_val)
+    }
+
+    #[test]
+    fn test_infer_fold_param() {
+        // The `xs: _` param is narrowed to `List<i32>` by the lambda's
+        // second parameter type. Defn's signature reflects that narrowing.
+        let ty = type_check_seq(&[
+            "(defn sum [xs: _] -> i32 (fold (fn [a: i32 x: i32] -> i32 (+ a x)) 0 xs))",
+        ])
+        .unwrap();
+        match ty {
+            Type::Function { params, return_type } => {
+                assert_eq!(params.len(), 1);
+                match &params[0] {
+                    Type::List(inner) => assert!(matches!(**inner, Type::I32)),
+                    other => panic!("expected List<i32> param, got {}", other),
+                }
+                assert!(matches!(*return_type, Type::I32));
+            }
+            other => panic!("expected function type, got {}", other),
+        }
+    }
+
+    #[test]
+    fn test_infer_fold_call() {
+        // After refinement, `(sum (list 1 2 3))` type-checks and evaluates.
+        let v = run_seq(&[
+            "(defn sum [xs: _] -> i32 (fold (fn [a: i32 x: i32] -> i32 (+ a x)) 0 xs))",
+            "(sum (list 1 2 3))",
+        ])
+        .unwrap();
+        assert!(matches!(v, Value::Integer32(6)));
+    }
+
+    #[test]
+    fn test_infer_length() {
+        // `length` arg is `List<_>`; `xs: _` narrows to `List<_>`.
+        let ty = type_check_seq(&["(defn len [xs: _] -> i32 (length xs))"]).unwrap();
+        match ty {
+            Type::Function { params, return_type } => {
+                assert_eq!(params.len(), 1);
+                assert!(matches!(&params[0], Type::List(_)));
+                assert!(matches!(*return_type, Type::I32));
+            }
+            other => panic!("expected function, got {}", other),
+        }
+    }
+
+    #[test]
+    fn test_infer_car() {
+        let ty = type_check_seq(&["(defn head [xs: _] -> i32 (car xs))"]).unwrap();
+        assert!(matches!(ty, Type::Function { .. }));
+    }
+
+    #[test]
+    fn test_infer_filter() {
+        let ty = type_check_seq(&[
+            "(defn keep [xs: _] -> List<i32> (filter (fn [x: i32] -> bool (> x 0)) xs))",
+        ])
+        .unwrap();
+        match ty {
+            Type::Function { params, .. } => match &params[0] {
+                Type::List(inner) => assert!(matches!(**inner, Type::I32)),
+                other => panic!("expected List<i32>, got {}", other),
+            },
+            other => panic!("expected function, got {}", other),
+        }
+    }
+
+    #[test]
+    fn test_infer_map() {
+        let ty = type_check_seq(&[
+            "(defn double [xs: _] -> List<i32> (map (fn [x: i32] -> i32 (* x 2)) xs))",
+        ])
+        .unwrap();
+        match ty {
+            Type::Function { params, .. } => match &params[0] {
+                Type::List(inner) => assert!(matches!(**inner, Type::I32)),
+                other => panic!("expected List<i32>, got {}", other),
+            },
+            other => panic!("expected function, got {}", other),
+        }
+    }
+
+    #[test]
+    fn test_infer_match_cons_only_errors() {
+        // After Step 5 refinement, exhaustiveness sees `List<_>` and the
+        // missing `nil` case is reported.
+        let err = type_check_seq(&[
+            "(defn f [xs: _] -> i32 (match xs ((cons h _) h)))",
+        ])
+        .unwrap_err();
+        assert!(
+            err.contains("not exhaustive") && err.contains("nil"),
+            "expected missing nil, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_infer_match_full() {
+        // Both `cons` and `nil` arms cover `List<_>` exhaustively.
+        let ty = type_check_seq(&[
+            "(defn f [xs: _] -> i32 (match xs ((cons h _) h) (nil 0)))",
+        ])
+        .unwrap();
+        assert!(matches!(ty, Type::Function { .. }));
+    }
+
+    #[test]
+    fn test_infer_complex_scrutinee_unchanged() {
+        // The scrutinee is not a plain symbol, so no refinement happens
+        // (the literal already has a concrete `List<i32>` type).
+        let ty = type_check_seq(&[
+            "(match (cons 1 nil) ((cons h _) h) (nil 0))",
+        ])
+        .unwrap();
+        assert!(matches!(ty, Type::I32));
+    }
+
+    #[test]
+    fn test_infer_null_check() {
+        let ty = type_check_seq(&["(defn is-empty [xs: _] -> bool (null? xs))"]).unwrap();
+        assert!(matches!(ty, Type::Function { .. }));
+    }
+
+    #[test]
+    fn test_infer_conflict() {
+        // `(length xs)` narrows xs to `List<_>`; then `(+ xs 1)` would
+        // require an integer — the call's argument-type check rejects it
+        // because `+` expects two operands compatible with the same
+        // (Inferred) parameter, but `List<_>` and `i32` do not match.
+        let err = type_check_seq(&[
+            "(defn bad [xs: _] -> i32 (+ (length xs) (car xs)))",
+        ]);
+        // After length narrows to List<_>, car narrows further if needed.
+        // This particular combination should still type-check because car
+        // returns Inferred. Use a clearer conflict instead:
+        // try `(length xs)` then add `xs` directly to an int, which can't
+        // satisfy the parameter type of `+`.
+        let _ = err;
+        let err2 = type_check_seq(&[
+            "(defn bad [xs: _] -> i32 (+ (length xs) xs))",
+        ])
+        .unwrap_err();
+        assert!(
+            err2.contains("Type mismatch") || err2.contains("expected"),
+            "expected a type error mixing list and int, got: {}",
+            err2
+        );
+    }
+
+    #[test]
+    fn test_infer_signature_visible_at_call() {
+        // After defn, the signature is `List<i32> -> i32`. Calling with
+        // `List<String>` should be rejected.
+        let err = type_check_seq(&[
+            "(defn sum [xs: _] -> i32 (fold (fn [a: i32 x: i32] -> i32 (+ a x)) 0 xs))",
+            "(sum (list \"a\" \"b\"))",
+        ])
+        .unwrap_err();
+        assert!(
+            err.contains("Type mismatch") || err.contains("expected"),
+            "expected type error from passing List<String> to sum, got: {}",
             err
         );
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,11 @@ use std::collections::HashMap;
 #[derive(Debug, Clone)]
 pub struct TypeEnv {
     types: HashMap<String, Type>,
+    /// Bidirectional inference (段階 A): records the concrete types into
+    /// which `Inferred` parameters were narrowed during body type-checking.
+    /// `Defn` reads this back to refine its registered function signature
+    /// after the body is checked.
+    pub refinements: HashMap<String, Type>,
 }
 
 impl TypeEnv {
@@ -120,20 +125,71 @@ impl TypeEnv {
             return_type: Box::new(Type::Inferred),
         });
         
-        TypeEnv { types }
+        TypeEnv { types, refinements: HashMap::new() }
     }
-    
+
     pub fn get(&self, name: &str) -> Option<&Type> {
         self.types.get(name)
     }
-    
+
     pub fn insert(&mut self, name: String, ty: Type) {
         self.types.insert(name, ty);
     }
-    
+
     pub fn extend(&self) -> Self {
+        // Child scope inherits known types but starts with a fresh
+        // refinements map. Each function body is its own refinement
+        // scope; `Defn` lifts only the params it cares about.
         TypeEnv {
             types: self.types.clone(),
+            refinements: HashMap::new(),
+        }
+    }
+
+    /// Bidirectional inference (段階 A): narrow `name`'s type to `ty`.
+    ///
+    /// - If `name` is unknown, no-op (only call this for known variables).
+    /// - If `name` is currently `Inferred`, replace with `ty`.
+    /// - If `name` is currently `List<Inferred>` and `ty` is a more concrete
+    ///   list type, replace with `ty`.
+    /// - If `name` is already concrete and matches `ty`, no-op.
+    /// - Otherwise, return a conflict error.
+    pub fn refine(&mut self, name: &str, ty: Type) -> Result<(), String> {
+        let current = match self.types.get(name) {
+            Some(c) => c.clone(),
+            None => return Ok(()),
+        };
+        match current {
+            Type::Inferred => {
+                self.types.insert(name.to_string(), ty.clone());
+                self.refinements.insert(name.to_string(), ty);
+                Ok(())
+            }
+            Type::List(ref inner) if matches!(**inner, Type::Inferred) => {
+                // `List<_>` accepts narrowing to a more concrete list type.
+                if matches!(ty, Type::List(_)) {
+                    self.types.insert(name.to_string(), ty.clone());
+                    self.refinements.insert(name.to_string(), ty);
+                    Ok(())
+                } else if types_match(&current, &ty) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "parameter `{}` was previously {} but now requires {}",
+                        name, current, ty
+                    ))
+                }
+            }
+            existing => {
+                if types_match(&existing, &ty) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "parameter `{}` was previously {} but now requires {}",
+                        name, existing, ty
+                    ))
+                }
+            }
         }
     }
 }
@@ -212,24 +268,43 @@ pub fn type_check(expr: &Expr, env: &mut TypeEnv) -> Result<Type, String> {
                 return_type: Box::new(return_type.clone()),
             };
             env.insert(name.clone(), func_type.clone());
-            
+
             // Now type-check the body with the function in scope
             let mut new_env = env.extend();
-            
+
             for (param_name, param_type) in params {
                 new_env.insert(param_name.clone(), param_type.clone());
             }
-            
+
             let body_type = type_check(body, &mut new_env)?;
-            
-            if &body_type != return_type && return_type != &Type::Inferred {
+
+            if !types_match(&body_type, return_type) && return_type != &Type::Inferred {
                 return Err(format!(
                     "Return type mismatch: expected {}, got {}",
                     return_type, body_type
                 ));
             }
-            
-            Ok(func_type)
+
+            // Bidirectional inference (段階 A): if any `_` parameters were
+            // narrowed during body type-checking, reflect them in the
+            // signature so external callers see the precise type.
+            let refined_params: Vec<Type> = params
+                .iter()
+                .map(|(pname, ptype)| {
+                    new_env
+                        .refinements
+                        .get(pname)
+                        .cloned()
+                        .unwrap_or_else(|| ptype.clone())
+                })
+                .collect();
+            let refined_func_type = Type::Function {
+                params: refined_params,
+                return_type: Box::new(return_type.clone()),
+            };
+            env.insert(name.clone(), refined_func_type.clone());
+
+            Ok(refined_func_type)
         }
         
         Expr::Lambda { params, return_type, body } => {
@@ -258,7 +333,19 @@ pub fn type_check(expr: &Expr, env: &mut TypeEnv) -> Result<Type, String> {
         }
         
         Expr::Match { scrutinee, arms } => {
-            let scrutinee_type = type_check(scrutinee, env)?;
+            let mut scrutinee_type = type_check(scrutinee, env)?;
+
+            // Bidirectional inference (段階 A): if the scrutinee is a plain
+            // variable that we still see as Inferred, but the arms reveal
+            // structural usage (cons or nil), narrow it to `List<_>` so the
+            // per-arm type checks and exhaustiveness see a real list type.
+            if matches!(scrutinee_type, Type::Inferred)
+                && let Expr::Symbol(sym) = &**scrutinee
+                && arms.iter().any(|(p, _)| is_list_shaped(p))
+            {
+                env.refine(sym, Type::List(Box::new(Type::Inferred)))?;
+                scrutinee_type = Type::List(Box::new(Type::Inferred));
+            }
 
             // Validate each arm. Bindings introduced by the pattern are
             // visible only in that arm's body — we clone the env so
@@ -305,7 +392,7 @@ pub fn type_check(expr: &Expr, env: &mut TypeEnv) -> Result<Type, String> {
                     }
                     
                     let mut actual_return_type = *return_type.clone();
-                    
+
                     for (i, (arg, param_type)) in args.iter().zip(params.iter()).enumerate() {
                         let arg_type = type_check(arg, env)?;
                         // Check type compatibility
@@ -314,6 +401,16 @@ pub fn type_check(expr: &Expr, env: &mut TypeEnv) -> Result<Type, String> {
                                 "Type mismatch in argument: expected {}, got {}",
                                 param_type, arg_type
                             ));
+                        }
+                        // Bidirectional inference (段階 A): if the parameter
+                        // expects a list (any list, possibly `List<_>`) and
+                        // the argument is an `Inferred` symbol, narrow that
+                        // symbol to `List<_>` so subsequent uses see a list.
+                        if matches!(arg_type, Type::Inferred)
+                            && matches!(param_type, Type::List(_))
+                            && let Expr::Symbol(sym) = arg
+                        {
+                            env.refine(sym, Type::List(Box::new(Type::Inferred)))?;
                         }
                         // Special handling for list operations
                         if let Expr::Symbol(fname) = &**func {
@@ -424,6 +521,15 @@ pub fn type_check(expr: &Expr, env: &mut TypeEnv) -> Result<Type, String> {
                                 param_types[0], elem_type
                             ));
                         }
+                        // Bidirectional inference (段階 A): narrow the source
+                        // variable when the list type is still Inferred but
+                        // the lambda's parameter type is concrete.
+                        if matches!(lst_type, Type::Inferred)
+                            && let Expr::Symbol(sym) = &exprs[2]
+                            && !matches!(param_types[0], Type::Inferred)
+                        {
+                            env.refine(sym, Type::List(Box::new(param_types[0].clone())))?;
+                        }
                         // If the function's return type is unresolved, the list
                         // element type is the best guess we have.
                         let result_elem = if ret_type == Type::Inferred {
@@ -462,7 +568,22 @@ pub fn type_check(expr: &Expr, env: &mut TypeEnv) -> Result<Type, String> {
                                 ret_type
                             ));
                         }
-                        Ok(Type::List(Box::new(elem_type)))
+                        // Bidirectional inference (段階 A): narrow the source
+                        // variable from the predicate's parameter type.
+                        if matches!(lst_type, Type::Inferred)
+                            && let Expr::Symbol(sym) = &exprs[2]
+                            && !matches!(param_types[0], Type::Inferred)
+                        {
+                            env.refine(sym, Type::List(Box::new(param_types[0].clone())))?;
+                        }
+                        let result_elem = if matches!(elem_type, Type::Inferred)
+                            && !matches!(param_types[0], Type::Inferred)
+                        {
+                            param_types[0].clone()
+                        } else {
+                            elem_type
+                        };
+                        Ok(Type::List(Box::new(result_elem)))
                     }
                     "fold" => {
                         // (fold f init lst) : B where f : B -> A -> B, init : B, lst : List<A>
@@ -499,6 +620,14 @@ pub fn type_check(expr: &Expr, env: &mut TypeEnv) -> Result<Type, String> {
                                 "fold return type {} does not match accumulator type {}",
                                 ret_type, init_type
                             ));
+                        }
+                        // Bidirectional inference (段階 A): narrow the source
+                        // variable from the lambda's element-parameter type.
+                        if matches!(lst_type, Type::Inferred)
+                            && let Expr::Symbol(sym) = &exprs[3]
+                            && !matches!(param_types[1], Type::Inferred)
+                        {
+                            env.refine(sym, Type::List(Box::new(param_types[1].clone())))?;
                         }
                         // Prefer the concrete init type over any Inferred from
                         // the function's return slot.
@@ -580,6 +709,11 @@ pub fn parse_type(s: &str) -> Result<Type, String> {
 fn expect_list_elem(ty: &Type, op: &str) -> Result<Type, String> {
     match ty {
         Type::List(elem) => Ok(*elem.clone()),
+        // Bidirectional inference (段階 A): an unresolved scrutinee is
+        // accepted here. Caller will narrow the source variable via
+        // `TypeEnv::refine` once the function/lambda parameter types are
+        // known.
+        Type::Inferred => Ok(Type::Inferred),
         _ => Err(format!("{} expects a list, got {}", op, ty)),
     }
 }
@@ -589,6 +723,19 @@ fn expect_function(ty: &Type, op: &str) -> Result<(Vec<Type>, Type), String> {
     match ty {
         Type::Function { params, return_type } => Ok((params.clone(), *return_type.clone())),
         _ => Err(format!("{} expects a function, got {}", op, ty)),
+    }
+}
+
+/// Strip `As` wrappers and report whether the underlying pattern is a
+/// list-shaped constructor (`cons` or `nil`). Used by the bidirectional
+/// scrutinee refinement in `Match` to decide when an `Inferred` scrutinee
+/// can be narrowed to `List<_>`.
+fn is_list_shaped(pat: &Pattern) -> bool {
+    match pat {
+        Pattern::Cons(_, _) | Pattern::Nil => true,
+        Pattern::As(inner, _) => is_list_shaped(inner),
+        Pattern::Guard(inner, _) => is_list_shaped(inner),
+        _ => false,
     }
 }
 
@@ -651,11 +798,13 @@ fn check_pattern(
                 check_pattern(tail, scrutinee, env)?;
                 Ok(())
             }
-            Type::Inferred => {
-                check_pattern(head, &Type::Inferred, env)?;
-                check_pattern(tail, &Type::Inferred, env)?;
-                Ok(())
-            }
+            // After bidirectional refinement (段階 A), an `Inferred`
+            // scrutinee should have been narrowed to `List<_>` before we
+            // get here. Surface a defensive internal error if not — this
+            // signals a missing refinement site rather than a user bug.
+            Type::Inferred => Err(
+                "internal: cons pattern reached Inferred scrutinee — should have been refined".to_string()
+            ),
             _ => Err(format!("cons pattern requires a list, got {}", scrutinee)),
         },
         Pattern::As(inner, _) => check_pattern(inner, scrutinee, env),


### PR DESCRIPTION
## Summary

`_` で書かれた関数パラメータが本体内での使われ方から自動的に絞り込まれるようになりました (Rust 流の双方向型推論、段階 A)。Issue #8 の動機例 — `xs: _` が `fold` などの組み込みで意味のある型に解決されない問題 — を解消します。

絞り込みの手がかり:
- `fold` / `map` / `filter` のラムダ引数型
- 単項リスト操作 (`length` / `car` / `cdr` / `null?` / `nth` / `append` / `cons`)
- `match` の `cons` / `nil` パターン

絞り込まれた型は `Defn` のシグネチャに反映されるため、呼び出し側からも見えます。

```lisp
> (defn sum [xs: _] -> i32
    (fold (fn [a: i32 x: i32] -> i32 (+ a x)) 0 xs))
#<function:1>: fn(List<i32>) -> i32   ; ← 絞り込み後のシグネチャ

> (sum (list 1 2 3 4 5))
15: i32
```

## 実装の要点

- `TypeEnv` に `refinements: HashMap<String, Type>` を追加し、`refine(name, ty)` で衝突検知付きの絞り込みを行う。型変数 (`Type::TyVar`) は導入していない — rustc の `InferCtxt` テーブルの縮小版という位置づけ
- `expect_list_elem` が `Inferred` を受容するよう拡張 (後段で絞り込まれる前提)
- `map` / `filter` / `fold` arm で「scrutinee が変数 + ラムダ引数が concrete」のとき `env.refine()` を発火
- `Call` arm に汎用 refine トリガを追加。`List<...>` を期待する組み込みに `Inferred` 変数が渡ったら `List<_>` に narrow
- `Match` arm で「scrutinee が変数 + Cons/Nil パターンあり + 型 Inferred」なら事前に `List<_>` に narrow
- `Defn` 本体型チェック後 `new_env.refinements` を読んで `func_type` を組み直し env に登録
- `check_pattern` の `Cons + Inferred` 分岐は defensive Err 化 (Step 5 で事前 narrow されているはず)

## Out of scope

- ユーザ定義関数からの逆推論 (段階 B)
- ラムダ引数 `_` の完全推論 (段階 C)
- 真の多相 (`forall T. List<T> -> T`) ・ `Type::TyVar`
- let 多相 / generalization

## Test plan

- [x] `cargo test` — 127 passed (新規 11 + 1 件書き換え含む)
- [x] `cargo clippy --all-targets -- -D warnings` 警告なし
- [x] REPL スモーク (動機例) — 期待通り `fn(List<i32>) -> i32` に narrow され `15: i32` を返す
- [x] 既存の `test_eval_match_recursive_sum` (`xs: _` + nil/cons 両アーム) もそのまま通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)