### PR TITLE
feat: Add or-patterns `(or p1 p2 ...)` for match expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Type 'exit' or press Ctrl+C to quit
 - `(list p1 p2 ...)` — ちょうどN要素のリストに位置でマッチ（`cons` 連鎖の糖衣）
 - `(as <pat> <name>)` — `<pat>` にマッチしつつ、値全体を `<name>` でも束縛
 - `(guard <pat> <expr>)` — `<pat>` にマッチしつつ、`<expr>`（bool）が真のときだけ成立。`<pat>` で束縛した変数は `<expr>` 内で使える
+- `(or <pat> <pat> ...)` — いずれかの枝にマッチ。**全枝が同じ名前・同じ型の変数を束縛**しなければなりません（健全性のため）。1 枝以上必要
 
 `Bool` と `List<T>` を scrutinee にした `match` は **型チェック時に網羅性を検証** します。ケースが漏れていると不足パターンを示すエラーになります（`_` や変数で全受けすれば回避可）:
 
@@ -325,7 +326,23 @@ Error: match is not exhaustive: missing patterns: (cons _ _)
 
 > (classify -3)
 "negative": String
+
+; (or ...) パターン: 複数のケースをまとめる
+> (match 2 ((or 1 2 3) "small") ((or 10 20) "medium") (_ "other"))
+"small": String
+
+; or 内で同名変数を束縛する場合は全枝で同じ型である必要があります
+> (match (list 1 2)
+    ((or (cons 1 _) (cons _ (cons 1 _))) "has-one")
+    (_ "no-one"))
+"has-one": String
+
+; 異なる名前を束縛するとコンパイルエラー（健全性チェック）
+> (match 1 ((or x 2) 0) (_ -1))
+Error: or-pattern: variable `x` bound in some branches but not others
 ```
+
+ガード内の `or` (`(guard (or 1 2) (...))`) は guard の不透明性を保つため、網羅性検査では展開されません。`(or _ 1)` のような到達不能な枝は現状サイレントに通します（将来 `unreachable_patterns` 警告として扱う予定）。
 
 ## プロジェクト構造
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -67,6 +67,10 @@ pub enum Pattern {
     /// `<expr>` to evaluate to `true` in the env extended with `<pat>`'s
     /// bindings. Used to express conditional pattern arms without nesting `if`.
     Guard(Box<Pattern>, Box<Expr>),
+    /// `(or p1 p2 ...)` — match if any branch matches. All branches must
+    /// bind the same set of names with the same types (soundness). The
+    /// first matching branch's bindings are used by the arm body.
+    Or(Vec<Pattern>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -202,6 +206,13 @@ impl fmt::Display for Pattern {
             Pattern::Cons(head, tail) => write!(f, "(cons {} {})", head, tail),
             Pattern::As(inner, name) => write!(f, "({} as {})", inner, name),
             Pattern::Guard(inner, expr) => write!(f, "(guard {} {})", inner, expr),
+            Pattern::Or(branches) => {
+                write!(f, "(or")?;
+                for b in branches {
+                    write!(f, " {}", b)?;
+                }
+                write!(f, ")")
+            }
         }
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -453,4 +453,15 @@ impl Environment {
             parent: Some(Box::new(self.clone())),
         }
     }
+
+    /// Capture the current local-scope bindings (parent chain unchanged).
+    /// Used by or-pattern evaluation to restore state after a failed branch.
+    pub fn snapshot(&self) -> HashMap<String, Value> {
+        self.values.clone()
+    }
+
+    /// Replace the local-scope bindings with `snap`. Pairs with `snapshot`.
+    pub fn restore(&mut self, snap: HashMap<String, Value>) {
+        self.values = snap;
+    }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -259,6 +259,19 @@ fn pattern_match(pattern: &Pattern, value: &Value, env: &mut Environment) -> boo
             // result here is treated as a failed match defensively.
             matches!(eval(guard_expr, env), Ok(Value::Bool(true)))
         }
+        (Pattern::Or(branches), v) => {
+            // Try each branch left-to-right. On failure, restore the env
+            // so partial bindings from the failed branch don't leak into
+            // the next attempt or the arm body.
+            let snap = env.snapshot();
+            for b in branches {
+                if pattern_match(b, v, env) {
+                    return true;
+                }
+                env.restore(snap.clone());
+            }
+            false
+        }
         _ => false,
     }
 }

--- a/src/exhaustiveness.rs
+++ b/src/exhaustiveness.rs
@@ -31,7 +31,16 @@ const MAX_DEPTH: usize = 3;
 /// Entry point. Returns Ok if `arms` cover every value of `scrutinee`,
 /// otherwise an error listing the missing patterns.
 pub fn check(scrutinee: &Type, arms: &[&Pattern]) -> Result<(), String> {
-    let witnesses = missing(scrutinee, arms, 0);
+    // Flatten top-level `(or p1 p2 ...)` arms into sibling patterns so the
+    // existing constructor-based reduction sees them directly. We deliberately
+    // do NOT descend into Guard or Cons sub-patterns: guards stay opaque
+    // (their truth is runtime-known), and per-constructor recursion handles
+    // nested or-patterns through the arm list naturally.
+    let mut flat: Vec<&Pattern> = Vec::with_capacity(arms.len());
+    for a in arms {
+        flatten_or(a, &mut flat);
+    }
+    let witnesses = missing(scrutinee, &flat, 0);
     if witnesses.is_empty() {
         return Ok(());
     }
@@ -40,6 +49,21 @@ pub fn check(scrutinee: &Type, arms: &[&Pattern]) -> Result<(), String> {
         "match is not exhaustive: missing patterns: {}",
         rendered.join(", ")
     ))
+}
+
+/// Flatten top-level `(or ...)` and `(p as name)` wrappers into the
+/// underlying constructor patterns. `Guard` is a hard stop — its
+/// runtime opacity must be preserved for soundness.
+fn flatten_or<'a>(pat: &'a Pattern, out: &mut Vec<&'a Pattern>) {
+    match pat {
+        Pattern::Or(branches) => {
+            for b in branches {
+                flatten_or(b, out);
+            }
+        }
+        Pattern::As(inner, _) => flatten_or(inner, out),
+        _ => out.push(pat),
+    }
 }
 
 /// Strip away outer `As` wrappers so structural inspection sees the inner

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -432,6 +432,21 @@ fn parse_compound_pattern(
                 crate::ast::Pattern::Guard(Box::new(inner), Box::new(guard_expr)),
             ))
         }
+        "or" => {
+            // (or <pat> <pat> ...) — 1 or more branches required
+            let (input, branches) =
+                many0(preceded(multispace0, parse_pattern))(input)?;
+            let (input, _) = multispace0(input)?;
+            let (input, _) = char(')')(input)?;
+            if branches.is_empty() {
+                return Err(nom::Err::Failure(
+                    crate::parser::error::ParseError::UnexpectedInput(
+                        "(or ...) requires at least one branch".to_string(),
+                    ),
+                ));
+            }
+            Ok((input, crate::ast::Pattern::Or(branches)))
+        }
         other => Err(nom::Err::Failure(
             crate::parser::error::ParseError::UnexpectedInput(format!(
                 "unknown compound pattern: ({} ...)",

--- a/src/tests/eval_tests.rs
+++ b/src/tests/eval_tests.rs
@@ -1569,4 +1569,171 @@ mod tests {
             err
         );
     }
+
+    // ======================================================================
+    // Or-patterns `(or p1 p2 ...)`
+    // ======================================================================
+
+    #[test]
+    fn test_eval_or_literal_first_matches() {
+        // First branch of an or-pattern matches → arm is taken.
+        let result = eval_str(
+            "(match 1 ((or 1 2) \"a\") (_ \"b\"))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::String(ref s) if s == "a"));
+    }
+
+    #[test]
+    fn test_eval_or_literal_second_matches() {
+        // Second branch matches when the first does not.
+        let result = eval_str(
+            "(match 2 ((or 1 2) \"a\") (_ \"b\"))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::String(ref s) if s == "a"));
+    }
+
+    #[test]
+    fn test_eval_or_literal_no_match_falls_through() {
+        // No or-branch matches → fall through to next arm.
+        let result = eval_str(
+            "(match 3 ((or 1 2) \"a\") (_ \"b\"))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::String(ref s) if s == "b"));
+    }
+
+    #[test]
+    fn test_eval_or_with_shared_binding() {
+        // Both branches bind `h` at the head position with type i32. The
+        // first branch matches a single-element list, the second matches
+        // a 2+ element list whose first element we want to ignore.
+        let result = eval_str(
+            "(match (list 10 20) \
+               ((or (cons h nil) (cons _ (cons h _))) h) \
+               (_ -1))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::Integer32(20)));
+    }
+
+    #[test]
+    fn test_type_check_or_inconsistent_branch_types() {
+        // Mixing i32 and bool literals in the same or-pattern: the second
+        // branch can't possibly type-check against an i32 scrutinee.
+        let err = type_check_str(
+            "(match 1 ((or 1 true) \"x\") (_ \"y\"))",
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("Bool") || err.contains("Type") || err.contains("type"),
+            "expected a type error mixing i32 and bool, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_type_check_or_unequal_binding_sets() {
+        // `(or x 1)` binds `x` in the first branch but not the second.
+        let err = type_check_str(
+            "(match 1 ((or x 1) 0) (_ -1))",
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("bound in some branches but not others"),
+            "expected unequal-binding-sets error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_type_check_or_inconsistent_binding_types() {
+        // Both branches bind `h` but at different types: head of List<i32>
+        // is i32, but the whole list itself is List<i32>. (`as` exposes
+        // the whole value with the scrutinee's type.)
+        let err = type_check_str(
+            "(match (list 1 2) \
+               ((or (cons h _) (as _ h)) 0) \
+               (_ -1))",
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("inconsistent types"),
+            "expected inconsistent-types error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_eval_or_nested_flattens() {
+        // Nested or-patterns work via natural recursion in pattern_match.
+        let result = eval_str(
+            "(match 3 ((or (or 1 2) 3) \"hit\") (_ \"miss\"))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::String(ref s) if s == "hit"));
+    }
+
+    #[test]
+    fn test_eval_or_single_branch_passthrough() {
+        // A single-branch or-pattern behaves the same as the inner pattern.
+        let result = eval_str(
+            "(match 1 ((or 1) \"yes\") (_ \"no\"))",
+        )
+        .unwrap();
+        assert!(matches!(result, Value::String(ref s) if s == "yes"));
+    }
+
+    #[test]
+    fn test_exhaustive_or_covers_bool() {
+        // `(or true false)` covers all Bool values → no exhaustiveness error.
+        let result = type_check_str(
+            "(match (= 1 1) ((or true false) 1))",
+        );
+        assert!(
+            result.is_ok(),
+            "expected or to cover Bool exhaustively, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_exhaustive_or_partial_list() {
+        // `(or nil (cons 0 _))` covers nil + cons-with-head-0, leaving
+        // cons-with-other-head uncovered.
+        let err = type_check_str(
+            "(match (list 1 2) ((or nil (cons 0 _)) 1))",
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("not exhaustive"),
+            "expected exhaustiveness error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_eval_or_env_restore() {
+        // Both branches bind `h` (same name, same type — soundness OK), but
+        // they bind it to different positions. We craft a list where the
+        // first branch matches partially: its outer `cons` succeeds and
+        // binds `h = 1`, but the inner literal `99` fails. Without env
+        // restore, `h = 1` would leak into the second branch and be
+        // overwritten only if the second branch also matches at that name.
+        // Here the second branch binds `h = 20` (the second element). If
+        // restore is broken AND the match short-circuits oddly, we'd see
+        // the wrong value. Correct behavior: second branch binds h=20.
+        let result = eval_str(
+            "(match (list 1 2 20) \
+               ((or (cons h (cons 99 _)) (cons _ (cons _ (cons h nil)))) h) \
+               (_ -1))",
+        )
+        .unwrap();
+        assert!(
+            matches!(result, Value::Integer32(20)),
+            "expected 20 from second or-branch, got: {:?}",
+            result
+        );
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -735,7 +735,89 @@ fn is_list_shaped(pat: &Pattern) -> bool {
         Pattern::Cons(_, _) | Pattern::Nil => true,
         Pattern::As(inner, _) => is_list_shaped(inner),
         Pattern::Guard(inner, _) => is_list_shaped(inner),
+        // Any branch hinting at a list structure is enough to refine
+        // the scrutinee to `List<_>`. Mismatched branches (e.g. a literal
+        // i32 alongside a cons) will still be reported by check_pattern.
+        Pattern::Or(branches) => branches.iter().any(is_list_shaped),
         _ => false,
+    }
+}
+
+/// Pure version of `bind_pattern`: returns the (name, type) bindings that
+/// the pattern would introduce, without mutating any environment. Used for
+/// or-pattern soundness — every branch must produce the same set of
+/// bindings (same names, compatible types).
+fn collect_bindings(
+    pat: &Pattern,
+    scrutinee: &Type,
+) -> Result<HashMap<String, Type>, String> {
+    match pat {
+        Pattern::Wildcard
+        | Pattern::Nil
+        | Pattern::LiteralI32(_)
+        | Pattern::LiteralI64(_)
+        | Pattern::LiteralF64(_)
+        | Pattern::LiteralBool(_)
+        | Pattern::LiteralString(_) => Ok(HashMap::new()),
+        Pattern::Variable(name) => {
+            let mut m = HashMap::new();
+            m.insert(name.clone(), scrutinee.clone());
+            Ok(m)
+        }
+        Pattern::Cons(head, tail) => {
+            let (head_ty, tail_ty) = match scrutinee {
+                Type::List(elem) => (*elem.clone(), scrutinee.clone()),
+                _ => (Type::Inferred, Type::List(Box::new(Type::Inferred))),
+            };
+            let mut m = collect_bindings(head, &head_ty)?;
+            for (k, v) in collect_bindings(tail, &tail_ty)? {
+                m.insert(k, v);
+            }
+            Ok(m)
+        }
+        Pattern::As(inner, name) => {
+            let mut m = collect_bindings(inner, scrutinee)?;
+            m.insert(name.clone(), scrutinee.clone());
+            Ok(m)
+        }
+        Pattern::Guard(inner, _) => collect_bindings(inner, scrutinee),
+        Pattern::Or(branches) => {
+            // Defensive: parser rejects empty or, but guard the invariant.
+            if branches.is_empty() {
+                return Err("empty or-pattern".to_string());
+            }
+            let first = collect_bindings(&branches[0], scrutinee)?;
+            for b in &branches[1..] {
+                let m = collect_bindings(b, scrutinee)?;
+                // Same key sets in both directions.
+                for k in first.keys() {
+                    if !m.contains_key(k) {
+                        return Err(format!(
+                            "or-pattern: variable `{}` bound in some branches but not others",
+                            k
+                        ));
+                    }
+                }
+                for (k, v) in &m {
+                    match first.get(k) {
+                        None => {
+                            return Err(format!(
+                                "or-pattern: variable `{}` bound in some branches but not others",
+                                k
+                            ));
+                        }
+                        Some(expected) if !types_match(expected, v) => {
+                            return Err(format!(
+                                "or-pattern: variable `{}` has inconsistent types: {} vs {}",
+                                k, expected, v
+                            ));
+                        }
+                        Some(_) => {}
+                    }
+                }
+            }
+            Ok(first)
+        }
     }
 }
 
@@ -823,6 +905,17 @@ fn check_pattern(
             }
             Ok(())
         }
+        Pattern::Or(branches) => {
+            if branches.is_empty() {
+                return Err("empty or-pattern".to_string());
+            }
+            // Each branch must be type-compatible with the scrutinee.
+            for b in branches {
+                check_pattern(b, scrutinee, env)?;
+            }
+            // All branches must introduce the same (name, type) bindings.
+            collect_bindings(pattern, scrutinee).map(|_| ())
+        }
     }
 }
 
@@ -858,6 +951,14 @@ fn bind_pattern(pattern: &Pattern, scrutinee: &Type, env: &mut TypeEnv) {
         Pattern::Guard(inner, _) => {
             // Guard expr does not introduce bindings; the inner pattern does.
             bind_pattern(inner, scrutinee, env);
+        }
+        Pattern::Or(branches) => {
+            // `check_pattern` ensured all branches introduce the same
+            // (name, type) bindings, so binding from the first branch is
+            // sufficient for type-checking the arm body.
+            if let Some(first) = branches.first() {
+                bind_pattern(first, scrutinee, env);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- `(or p1 p2 ...)` を `match` のパターンに追加。複数ケースを単一アームでまとめられる
- 全枝が**同じ名前・同じ型の変数**を束縛することを型検査時に強制 (健全性、Rust/OCaml と同方針)
- 網羅性検査は最上位 Or を `flatten_or` で展開してから既存の Maranget reduction に渡す
- 失敗枝の partial binding は **Or アーム内のみ** snapshot/restore で巻き戻し、既存 `pattern_match` の Cons 短絡挙動は変えない

Closes #5.

## 設計判断

| 論点 | 決定 | 理由 |
|---|---|---|
| 構文 | `(or ...)` のみ | Lisp 文化との一貫性。`(\| ...)` 糖衣は導入しない |
| 1 枝のみ | 許容 | `Pattern::Or(vec![p])` で一様に扱える |
| 空 `(or)` | パーサで拒否 | AST に到達しない設計 |
| 束縛検証 | 純粋ヘルパ `collect_bindings` を新設 | `bind_pattern` は副作用関数。検証用に分離 |
| 全枝同名同型 | 強制 (差があればエラー) | 健全性 |
| dead branch | サイレント許容 (例: `(or _ 1)` の `1`) | 警告機構が現状ない、別 issue 化 |
| Guard 内 Or | 網羅性では展開しない | guard の不透明性を保つ |

## 実装サマリ

- `Pattern::Or(Vec<Pattern>)` variant 追加 + Display impl
- `parse_compound_pattern` に `\"or\"` arm。`(or)` は parser でエラー化
- `src/types.rs`: `collect_bindings` 新設、`check_pattern`/`bind_pattern`/`is_list_shaped` に Or arm
- `src/env.rs`: `snapshot()` / `restore()` API
- `src/eval.rs`: `pattern_match` に Or arm (snapshot/restore で失敗枝を巻き戻し)
- `src/exhaustiveness.rs`: `flatten_or` ヘルパ + `check` 入口で適用
- `README.md`: pattern matching セクションに or-pattern 例を追加

## Out of scope (別 issue で扱う)

- `(\| p1 p2)` 糖衣構文
- `unreachable_patterns` 警告 (`(or _ 1)` の dead 検出)
- LLVM 化 (枝展開で扱える、別タスク)
- `pattern_match` 全体の env restore 契約変更 (Or 内ローカル化のみ)

## Test plan

- [x] `cargo build` グリーン
- [x] `cargo clippy --all-targets -- -D warnings` グリーン
- [x] `cargo test` 139/139 (127 既存 + 12 新規)
- [x] REPL スモークテスト (`classify` 関数、入れ子 or、共有束縛、エラーケース全種)
- [x] エラーメッセージ確認: 束縛集合不一致 / 束縛型不整合 / 枝型不整合 / 網羅性 / 空 or

REPL 出力サンプル:

```
> (defn classify [n: i32] -> String
    (match n
      ((or 1 2 3) "small")
      ((or 10 20) "medium")
      (_ "other")))
> (classify 2)
"small": String
> (classify 20)
"medium": String

> (match 1 ((or x 1) 0) (_ -1))
Error: or-pattern: variable `x` bound in some branches but not others
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)