### PR TITLE
feat: LLVM backend MVP (JIT + AOT, scalar/function/recursion scope)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Rusp is a typed Lisp implemented in Rust (edition 2024): S-expression syntax with static type checking and inference. Currently ships a REPL; the project is pre-1.0 and evolving. See `README.md` (Japanese) for the user-facing language reference, and `docs/language-design.md` for the design spec.
 
-Dependencies are minimal — only `nom` 7.1 for parsing. No external runtime.
+Dependencies: `nom` 7.1 (parser) and `inkwell` 0.9 + LLVM 18 (codegen backend). The `nix develop` shell sets `LLVM_SYS_181_PREFIX`; outside the shell, `cargo` won't find LLVM.
 
 ## Essential Commands
 
-- `cargo run` — start the REPL
-- `cargo test` — run all tests; `cargo test [name]` for a single test; add `-- --nocapture` to see `println!` output
-- `cargo clippy` / `cargo fmt` — lint and format
+- `nix develop --command cargo run` — start the REPL
+- `nix develop --command cargo run -- --llvm` — REPL with LLVM JIT backend
+- `nix develop --command cargo run -- build FILE --emit ll|obj` — AOT compile to `FILE.ll` / `FILE.o`
+- `nix develop --command cargo test` — run all tests; `cargo test [name]` for a single test; add `-- --nocapture` to see `println!` output
+- `nix develop --command cargo clippy --all-targets -- -D warnings` / `cargo fmt` — lint and format
 
 ## Architecture
 
@@ -23,6 +25,7 @@ The REPL loop in `src/main.rs` runs every input through three sequential stages 
 - `src/types.rs` — type checker + `TypeEnv`. Inference fills in `Type::Inferred` placeholders.
 - `src/eval.rs` — tree-walking evaluator. Assumes type-check has already passed.
 - `src/env.rs` — runtime `Value` definitions and `Environment` with parent-chain lexical scoping. Built-in arithmetic/comparison/logic ops and `print`/`println`/`type-of` are registered here as `Value::BuiltinFunction`, not special-cased in the evaluator.
+- `src/codegen/` — LLVM backend (MVP). `jit.rs` covers JIT (`jit_eval_*_program`) including the shared `emit_defn` and `ExprCg` (per-invocation codegen helper carrying `module`, `builder`, `env`, `functions`, and a `lambda_counter`). `aot.rs` reuses `emit_defn` to produce a textual LLVM IR string or a native object file. The `EmitVal` enum (`Int` / `Float` / `FuncRef`) discriminates SSA value kinds; `FuncRef` has no boundary representation and is rejected at returns. MVP scope is scalar types + functions + recursion; `List`, `match`, and `String` are out of scope.
 
 ### Design points worth knowing before editing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,84 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "inkwell"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7decbc9dfa45a4a827a6ff7b822c113b1285678a937e84213417d4ca8a095782"
+dependencies = [
+ "bitflags",
+ "inkwell_internals",
+ "libc",
+ "llvm-sys",
+ "thiserror",
+]
+
+[[package]]
+name = "inkwell_internals"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cfe97ee860815a90ed17e09639513269e39420a7440f3f4c996f238c514cf8d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "llvm-sys"
+version = "181.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24aad69cbdb0c6ebe777262e9e6314dceba0d6e6a2a63e47563ccd293a2eda8"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
+ "semver",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,8 +103,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "rusp"
 version = "0.1.0"
 dependencies = [
+ "inkwell",
  "nom",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 nom = "7.1"
+inkwell = { version = "0.9", features = ["llvm18-1"] }

--- a/README.md
+++ b/README.md
@@ -397,6 +397,58 @@ Error: 99999999999999999999 is out of i32 range
 - [ ] トレイトシステム
 - [ ] マクロシステム
 
+## LLVMバックエンド (MVP)
+
+Ruspはツリーウォーク型のインタプリタに加え、LLVMによるJITコンパイルとAOTコンパイルをサポートします (MVPスコープ: スカラ型・関数・再帰のみ。`List` / `match` / `String` は対象外)。
+
+### `--llvm` REPL (JIT)
+
+```bash
+cargo run -- --llvm
+```
+
+通常のREPLと同じ操作感で、各式が LLVM IR にコード生成され、JITで実行されます。型エラーは従来通り検査段階で報告されます。
+
+```lisp
+> (+ 1 2)
+3: i32
+> (defn sq [n: i32] -> i32 (* n n))
+> (sq 7)
+49: i32
+> (let twice (fn [x: i32] -> i32 (* x 2)) (twice 21))
+42: i32
+```
+
+`defn` は型環境とJIT再エミット用バッファに登録され、後続の式呼び出し時に再コード生成されます。
+
+### `rusp build` (AOT)
+
+ソースファイルを LLVM IR (`.ll`) または ネイティブオブジェクト (`.o`) にコンパイルします。ファイルは `defn` の連続で、最後に `(defn main [] -> i32 ...)` を含む必要があります。
+
+```bash
+# LLVM IRを書き出す
+cargo run -- build hello.rusp --emit ll
+# ネイティブオブジェクトを書き出す
+cargo run -- build hello.rusp --emit obj
+# リンクして実行ファイルを作成
+cc hello.rusp.o -o hello
+./hello; echo $?   # main の戻り値が exit code
+```
+
+例 (`hello.rusp`):
+
+```lisp
+(defn sq [n: i32] -> i32 (* n n))
+(defn main [] -> i32 (sq 6))
+```
+
+### MVPスコープ
+
+- 対応: `i32` / `i64` / `f64` / `bool` リテラル、整数・浮動小数点演算、比較、`if`、`and` / `or` / `not`、`let`-in、`defn` (相互参照・再帰可)、キャプチャ無しラムダ `(fn [...] -> T body)`
+- 非対応: `List` / `cons` / `nil`、`match`、`String`、ラムダの自由変数キャプチャ、ラムダの戻り型推論
+
+これらは将来のリリースで追加予定です。
+
 ## 開発
 
 ### ビルド

--- a/flake.nix
+++ b/flake.nix
@@ -25,18 +25,25 @@
           packages = [
             rustToolchain
             pkgs.pkg-config
+            pkgs.llvmPackages_18.llvm.dev
+            pkgs.libffi
+            pkgs.libxml2
+            pkgs.zlib
           ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
             pkgs.libiconv
           ];
 
           env = {
             RUST_BACKTRACE = "1";
+            # llvm-sys (transitive dep of inkwell) finds llvm-config via this prefix.
+            LLVM_SYS_181_PREFIX = "${pkgs.llvmPackages_18.llvm.dev}";
           };
 
           shellHook = ''
             echo "Rusp dev shell"
             echo "  $(rustc --version)"
             echo "  $(cargo --version)"
+            echo "  $(${pkgs.llvmPackages_18.llvm.dev}/bin/llvm-config --version | head -c 32) (LLVM)"
           '';
         };
       });

--- a/src/codegen/aot.rs
+++ b/src/codegen/aot.rs
@@ -1,0 +1,120 @@
+//! Ahead-of-time compilation: emit LLVM IR (`.ll`) or a native object
+//! file (`.o`) for a Rusp source file.
+//!
+//! The AOT pipeline reuses `emit_defn` from `jit.rs`. The input is a
+//! slice of fully-checked `Expr`s — currently restricted to a sequence
+//! of `defn`s, the last of which must be `(defn main [] -> i32 ...)`.
+//! The `main` defn becomes the C-ABI entry point of the produced
+//! object, so it can be linked with `cc` to make an executable.
+//!
+//! There is no support for top-level expressions in AOT mode — they
+//! have nowhere to live without a thunk, and rather than inventing
+//! one we keep the surface simple: write `(defn main [] -> i32 ...)`.
+
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::path::Path;
+
+use inkwell::OptimizationLevel;
+use inkwell::context::Context;
+use inkwell::targets::{
+    CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetMachine,
+};
+use inkwell::values::FunctionValue;
+
+use crate::ast::Expr;
+
+use super::jit::{JitError, emit_defn};
+
+/// Emit LLVM IR (textual `.ll`) for the program. The program must be a
+/// sequence of `defn`s ending with `(defn main [] -> i32 ...)`.
+/// Returns the IR as a string; the caller decides where to write it.
+pub fn compile_to_ll(forms: &[Expr]) -> Result<String, JitError> {
+    let context = Context::create();
+    let ir = build_module_ir(&context, forms)?;
+    Ok(ir)
+}
+
+/// Emit a native object file at `out_path` for the program. Same input
+/// shape as `compile_to_ll`. Uses the host triple and the default
+/// reloc/code models, which is good enough for `cc out.o -o out`.
+pub fn compile_to_obj(forms: &[Expr], out_path: &Path) -> Result<(), JitError> {
+    let context = Context::create();
+    let module = build_module(&context, forms)?;
+
+    // Initialize the native target backend. Cheap if already done.
+    Target::initialize_native(&InitializationConfig::default())
+        .map_err(|e| format!("failed to initialize native target: {}", e))?;
+    let triple = TargetMachine::get_default_triple();
+    let target = Target::from_triple(&triple)
+        .map_err(|e| format!("failed to look up target {}: {}", triple, e))?;
+    let cpu = TargetMachine::get_host_cpu_name();
+    let features = TargetMachine::get_host_cpu_features();
+    let machine = target
+        .create_target_machine(
+            &triple,
+            cpu.to_str().unwrap_or("generic"),
+            features.to_str().unwrap_or(""),
+            OptimizationLevel::Default,
+            RelocMode::PIC,
+            CodeModel::Default,
+        )
+        .ok_or_else(|| format!("failed to create target machine for {}", triple))?;
+
+    machine
+        .write_to_file(&module, FileType::Object, out_path)
+        .map_err(|e| format!("failed to write object file: {}", e))?;
+    Ok(())
+}
+
+/// Shared core: build the LLVM module from a slice of `defn` forms.
+/// Validates that the last form is `(defn main [] -> i32 ...)` and
+/// that no leading form is anything other than a `defn`.
+fn build_module<'ctx>(
+    context: &'ctx Context,
+    forms: &[Expr],
+) -> Result<inkwell::module::Module<'ctx>, JitError> {
+    if forms.is_empty() {
+        return Err("--emit: empty program (need at least `(defn main ...)`)".to_string());
+    }
+    for (i, f) in forms.iter().enumerate() {
+        if !matches!(f, Expr::Defn { .. }) {
+            return Err(format!(
+                "--emit: form {} is not a `defn`; AOT mode only supports a \
+                 sequence of `defn`s ending with `(defn main [] -> i32 ...)`",
+                i
+            ));
+        }
+    }
+    let last = forms.last().expect("non-empty by guard above");
+    let Expr::Defn { name, params, return_type, .. } = last else {
+        unreachable!("matches above guarantee Defn")
+    };
+    if name != "main" {
+        return Err(format!(
+            "--emit: program's last `defn` must be named `main`, got `{}`",
+            name
+        ));
+    }
+    if !params.is_empty() {
+        return Err("--emit: `main` must take zero parameters".to_string());
+    }
+    if !matches!(return_type, crate::ast::Type::I32) {
+        return Err("--emit: `main` must return `i32`".to_string());
+    }
+
+    let module = context.create_module("rusp_aot");
+    let builder = context.create_builder();
+    let mut functions: HashMap<String, FunctionValue<'_>> = HashMap::new();
+    let lambda_counter: Cell<u32> = Cell::new(0);
+    for f in forms {
+        emit_defn(context, &module, &builder, &mut functions, &lambda_counter, f)?;
+    }
+    Ok(module)
+}
+
+/// `build_module` + render to textual IR.
+fn build_module_ir(context: &Context, forms: &[Expr]) -> Result<String, JitError> {
+    let module = build_module(context, forms)?;
+    Ok(module.print_to_string().to_string())
+}

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -1,13 +1,14 @@
-//! Minimal JIT entry point for Steps 2–4: parse → type-check → codegen → run.
+//! Minimal JIT entry point for Steps 2–5: parse → type-check → codegen → run.
 //!
 //! Supports:
 //! - i32/i64 literals and integer arithmetic (`+`, `-`, `*`, `/`)
+//! - f64 literals and float arithmetic (`+.`, `-.`, `*.`, `/.`)
 //! - bool literals
-//! - integer comparison (`=`, `<`, `>`, `<=`, `>=`) — i32 and i64
+//! - comparison (`=`, `<`, `>`, `<=`, `>=`) on i32, i64, and f64
 //! - `if` (with phi-merge)
 //! - `and`/`or`/`not` (short-circuit for `and`/`or`, xor for `not`)
 //!
-//! The integer-arithmetic / comparison forms infer their width from the
+//! Integer arithmetic / comparison forms infer their width from the
 //! leading operand; the type checker has already enforced that every
 //! operand of one form shares that width.
 //!
@@ -20,8 +21,9 @@ use inkwell::OptimizationLevel;
 use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::execution_engine::ExecutionEngine;
-use inkwell::values::{FunctionValue, IntValue};
-use inkwell::{IntPredicate};
+use inkwell::types::{BasicType, BasicTypeEnum};
+use inkwell::values::{BasicValue, BasicValueEnum, FloatValue, FunctionValue, IntValue};
+use inkwell::{FloatPredicate, IntPredicate};
 
 use crate::ast::Expr;
 
@@ -37,14 +39,14 @@ pub fn jit_eval_i32(expr: &Expr) -> Result<i32, JitError> {
     let result = compile_and_run(&context, expr, ReturnKind::I32)?;
     // SAFETY of the cast: the JIT returned an i32 inside a u64 (we trampoline
     // through u64 to keep one signature for both widths). Truncation is safe.
-    Ok(result as i32)
+    Ok(result.as_u64 as i32)
 }
 
 /// Compile and JIT-run `expr` as an `i64`-returning thunk.
 pub fn jit_eval_i64(expr: &Expr) -> Result<i64, JitError> {
     let context = Context::create();
     let result = compile_and_run(&context, expr, ReturnKind::I64)?;
-    Ok(result as i64)
+    Ok(result.as_u64 as i64)
 }
 
 /// Compile and JIT-run `expr` as a `bool`-returning thunk.
@@ -56,16 +58,26 @@ pub fn jit_eval_i64(expr: &Expr) -> Result<i64, JitError> {
 pub fn jit_eval_bool(expr: &Expr) -> Result<bool, JitError> {
     let context = Context::create();
     let result = compile_and_run(&context, expr, ReturnKind::Bool)?;
-    Ok(result != 0)
+    Ok(result.as_u64 != 0)
+}
+
+/// Compile and JIT-run `expr` as an `f64`-returning thunk. Floats can't
+/// trampoline through u64 (different ABI registers, no bitcast at the
+/// boundary), so the float case is handled separately.
+pub fn jit_eval_f64(expr: &Expr) -> Result<f64, JitError> {
+    let context = Context::create();
+    let result = compile_and_run(&context, expr, ReturnKind::F64)?;
+    Ok(result.as_f64)
 }
 
 /// What the top-level thunk should return. Determines the function
-/// signature we emit and the cast applied at the FFI boundary.
+/// signature we emit and how the boundary value is interpreted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReturnKind {
     I32,
     I64,
     Bool,
+    F64,
 }
 
 impl ReturnKind {
@@ -74,27 +86,45 @@ impl ReturnKind {
             ReturnKind::I32 => "i32",
             ReturnKind::I64 => "i64",
             ReturnKind::Bool => "bool",
+            ReturnKind::F64 => "f64",
         }
     }
 }
 
-/// Compile, JIT, and run `__expr` returning a single integer-shaped
-/// value of the requested kind. The actual width affects only the
-/// function signature and the truncation/zero-extension at the
-/// boundary; codegen for the body itself dispatches on the value's
-/// own LLVM type.
+/// Boundary value carrier — `compile_and_run` returns either an integer
+/// (carried in u64) or a float (carried in f64). A union-style struct
+/// works fine here because exactly one field is meaningful per call,
+/// and `ReturnKind` tells the caller which.
+#[derive(Clone, Copy)]
+struct BoundaryValue {
+    as_u64: u64,
+    as_f64: f64,
+}
+
+impl BoundaryValue {
+    fn from_u64(v: u64) -> Self {
+        Self { as_u64: v, as_f64: 0.0 }
+    }
+    fn from_f64(v: f64) -> Self {
+        Self { as_u64: 0, as_f64: v }
+    }
+}
+
+/// Compile, JIT, and run `__expr` returning a single scalar of the
+/// requested kind.
 fn compile_and_run(
     context: &Context,
     expr: &Expr,
     expected: ReturnKind,
-) -> Result<u64, JitError> {
+) -> Result<BoundaryValue, JitError> {
     let module = context.create_module("rusp_jit");
     let builder = context.create_builder();
 
-    let ret_t = match expected {
-        ReturnKind::I32 => context.i32_type(),
-        ReturnKind::I64 => context.i64_type(),
-        ReturnKind::Bool => context.bool_type(),
+    let ret_t: BasicTypeEnum = match expected {
+        ReturnKind::I32 => context.i32_type().into(),
+        ReturnKind::I64 => context.i64_type().into(),
+        ReturnKind::Bool => context.bool_type().into(),
+        ReturnKind::F64 => context.f64_type().into(),
     };
     let fn_t = ret_t.fn_type(&[], false);
     let function = module.add_function("__expr", fn_t, None);
@@ -105,8 +135,8 @@ fn compile_and_run(
     let value = cg.emit(expr)?;
 
     // Width / kind validation: surface mismatches loudly so callers debug
-    // a width problem at the boundary rather than misreading bits.
-    let body_kind = ReturnKind::from_int_value(&value)?;
+    // a kind problem at the boundary rather than misreading bits.
+    let body_kind = value.return_kind()?;
     if body_kind != expected {
         return Err(format!(
             "JIT requested {} but expression produced {}",
@@ -115,16 +145,23 @@ fn compile_and_run(
         ));
     }
 
-    builder
-        .build_return(Some(&value))
-        .map_err(|e| format!("LLVM build_return failed: {}", e))?;
+    match value {
+        EmitVal::Int(iv) => builder
+            .build_return(Some(&iv as &dyn BasicValue))
+            .map(|_| ())
+            .map_err(|e| format!("LLVM build_return failed: {}", e))?,
+        EmitVal::Float(fv) => builder
+            .build_return(Some(&fv as &dyn BasicValue))
+            .map(|_| ())
+            .map_err(|e| format!("LLVM build_return failed: {}", e))?,
+    };
 
     let engine: ExecutionEngine = module
         .create_jit_execution_engine(OptimizationLevel::None)
         .map_err(|e| format!("failed to create JIT execution engine: {}", e))?;
 
     // SAFETY: We just emitted the function with the matching signature and
-    // verified the body's width above. The module is owned by `engine`,
+    // verified the body's kind above. The module is owned by `engine`,
     // both are dropped at end of scope.
     let result = unsafe {
         match expected {
@@ -132,35 +169,71 @@ fn compile_and_run(
                 let func = engine
                     .get_function::<unsafe extern "C" fn() -> i32>("__expr")
                     .map_err(|e| format!("failed to look up __expr: {}", e))?;
-                func.call() as u64
+                BoundaryValue::from_u64(func.call() as u64)
             }
             ReturnKind::I64 => {
                 let func = engine
                     .get_function::<unsafe extern "C" fn() -> i64>("__expr")
                     .map_err(|e| format!("failed to look up __expr: {}", e))?;
-                func.call() as u64
+                BoundaryValue::from_u64(func.call() as u64)
             }
             ReturnKind::Bool => {
-                // i1 → u8 at the boundary (see jit_eval_bool).
                 let func = engine
                     .get_function::<unsafe extern "C" fn() -> u8>("__expr")
                     .map_err(|e| format!("failed to look up __expr: {}", e))?;
-                func.call() as u64
+                BoundaryValue::from_u64(func.call() as u64)
+            }
+            ReturnKind::F64 => {
+                let func = engine
+                    .get_function::<unsafe extern "C" fn() -> f64>("__expr")
+                    .map_err(|e| format!("failed to look up __expr: {}", e))?;
+                BoundaryValue::from_f64(func.call())
             }
         }
     };
     Ok(result)
 }
 
-impl ReturnKind {
-    /// Map the bit-width of the body's SSA value to the matching ReturnKind.
-    /// i1 → Bool, i32 → I32, i64 → I64. Anything else is unsupported here.
-    fn from_int_value(v: &IntValue<'_>) -> Result<Self, JitError> {
-        match v.get_type().get_bit_width() {
-            1 => Ok(ReturnKind::Bool),
-            32 => Ok(ReturnKind::I32),
-            64 => Ok(ReturnKind::I64),
-            other => Err(format!("unsupported integer width: i{}", other)),
+/// SSA value produced by `emit`. We split int and float because LLVM's
+/// arithmetic / comparison instructions are typed and the dispatch is
+/// cleaner here than re-classifying via `BasicValueEnum` everywhere.
+#[derive(Clone, Copy)]
+enum EmitVal<'ctx> {
+    Int(IntValue<'ctx>),
+    Float(FloatValue<'ctx>),
+}
+
+impl<'ctx> EmitVal<'ctx> {
+    fn return_kind(&self) -> Result<ReturnKind, JitError> {
+        match self {
+            EmitVal::Int(iv) => match iv.get_type().get_bit_width() {
+                1 => Ok(ReturnKind::Bool),
+                32 => Ok(ReturnKind::I32),
+                64 => Ok(ReturnKind::I64),
+                other => Err(format!("unsupported integer width: i{}", other)),
+            },
+            EmitVal::Float(_) => Ok(ReturnKind::F64),
+        }
+    }
+
+    /// Friendly name for error messages. Mirrors `ReturnKind::name`
+    /// but avoids the `Result` for the common case.
+    fn type_name(&self) -> &'static str {
+        match self {
+            EmitVal::Int(iv) => match iv.get_type().get_bit_width() {
+                1 => "bool",
+                32 => "i32",
+                64 => "i64",
+                _ => "int(?)",
+            },
+            EmitVal::Float(_) => "f64",
+        }
+    }
+
+    fn as_basic_value_enum(&self) -> BasicValueEnum<'ctx> {
+        match self {
+            EmitVal::Int(iv) => (*iv).into(),
+            EmitVal::Float(fv) => (*fv).into(),
         }
     }
 }
@@ -175,28 +248,24 @@ struct ExprCg<'ctx, 'a> {
 }
 
 impl<'ctx, 'a> ExprCg<'ctx, 'a> {
-    /// Generate IR for `expr`, returning the resulting integer SSA value
-    /// (treating `bool` as `i1`).
-    fn emit(&self, expr: &Expr) -> Result<IntValue<'ctx>, JitError> {
+    /// Generate IR for `expr`, returning the resulting SSA value.
+    fn emit(&self, expr: &Expr) -> Result<EmitVal<'ctx>, JitError> {
         match expr {
-            Expr::Integer32(n) => {
-                // i32 literal — `const_int` reads the bits of the supplied
-                // u64; passing `true` for sign_extend handles negatives.
-                Ok(self.context.i32_type().const_int(*n as u64, true))
-            }
+            Expr::Integer32(n) => Ok(EmitVal::Int(
+                self.context.i32_type().const_int(*n as u64, true),
+            )),
 
-            Expr::Integer64(n) => {
-                Ok(self.context.i64_type().const_int(*n as u64, true))
-            }
+            Expr::Integer64(n) => Ok(EmitVal::Int(
+                self.context.i64_type().const_int(*n as u64, true),
+            )),
 
-            Expr::Bool(b) => {
-                Ok(self.context.bool_type().const_int(u64::from(*b), false))
-            }
+            Expr::Float(n) => Ok(EmitVal::Float(self.context.f64_type().const_float(*n))),
+
+            Expr::Bool(b) => Ok(EmitVal::Int(
+                self.context.bool_type().const_int(u64::from(*b), false),
+            )),
 
             // `if` is its own AST node (not a List with "if" symbol).
-            // Emit cond → conditional branch into then/else blocks → phi
-            // in a merge block. This is the textbook lowering, taken
-            // straight from the Kaleidoscope tutorial.
             Expr::If { condition, then_branch, else_branch } => {
                 self.emit_if(condition, then_branch, else_branch)
             }
@@ -207,7 +276,8 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
                 if let Expr::Symbol(op) = &exprs[0] {
                     let args = &exprs[1..];
                     match op.as_str() {
-                        "+" | "-" | "*" | "/" => self.gen_arith(op, args),
+                        "+" | "-" | "*" | "/" => self.gen_int_arith(op, args),
+                        "+." | "-." | "*." | "/." => self.gen_float_arith(op, args),
                         "=" | "<" | ">" | "<=" | ">=" => self.gen_cmp(op, args),
                         "and" => self.gen_and(args),
                         "or" => self.gen_or(args),
@@ -218,13 +288,10 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
                         )),
                     }
                 } else {
-                    Err("--llvm: only operator-headed lists are supported in Step 4".to_string())
+                    Err("--llvm: only operator-headed lists are supported in Step 5".to_string())
                 }
             }
 
-            // `Expr::Call` is what bare `(f x y)` parses to. For now we
-            // only handle the operator forms above. Calls land here only
-            // for user-defined functions, which Step 7 will enable.
             Expr::Call { .. } => {
                 Err("--llvm: function calls are not supported yet (Step 7)".to_string())
             }
@@ -238,10 +305,8 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
 
     /// Generate `(op arg0 arg1 ...)` for binary integer arithmetic.
     /// Variadic in source (`(+ 1 2 3)`) is left-folded. Width is taken
-    /// from the first operand; subsequent operands must match. The type
-    /// checker normally guarantees this, so a mismatch here is a bug
-    /// rather than user error.
-    fn gen_arith(&self, op: &str, args: &[Expr]) -> Result<IntValue<'ctx>, JitError> {
+    /// from the first operand.
+    fn gen_int_arith(&self, op: &str, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
         if args.len() < 2 {
             return Err(format!(
                 "operator `{}` requires at least 2 arguments, got {}",
@@ -249,17 +314,16 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
                 args.len()
             ));
         }
-
-        let mut acc = self.emit(&args[0])?;
+        let mut acc = self.expect_int(&self.emit(&args[0])?, op)?;
         let acc_width = acc.get_type().get_bit_width();
         if acc_width != 32 && acc_width != 64 {
             return Err(format!(
-                "operator `{}` requires integer operands, got i{}",
+                "operator `{}` requires i32/i64 operands, got i{}",
                 op, acc_width
             ));
         }
         for arg in &args[1..] {
-            let rhs = self.emit(arg)?;
+            let rhs = self.expect_int(&self.emit(arg)?, op)?;
             if rhs.get_type().get_bit_width() != acc_width {
                 return Err(format!(
                     "operator `{}`: operand width mismatch (i{} vs i{}) — \
@@ -289,13 +353,53 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
                 _ => unreachable!("operator dispatch checked already"),
             };
         }
-        Ok(acc)
+        Ok(EmitVal::Int(acc))
     }
 
-    /// Generate a binary integer comparison `(op a b)`. Result is `i1`.
-    /// Comparisons in Rusp are strictly binary (the type checker rejects
-    /// arity != 2), so we don't try to fold variadic forms.
-    fn gen_cmp(&self, op: &str, args: &[Expr]) -> Result<IntValue<'ctx>, JitError> {
+    /// Generate `(op. arg0 arg1 ...)` for binary float arithmetic.
+    /// Mirrors `gen_int_arith`. Rusp's float ops are syntactically
+    /// distinct from int ones (`+.` vs `+`), so the type checker has
+    /// already guaranteed every operand is f64.
+    fn gen_float_arith(&self, op: &str, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
+        if args.len() < 2 {
+            return Err(format!(
+                "operator `{}` requires at least 2 arguments, got {}",
+                op,
+                args.len()
+            ));
+        }
+        let mut acc = self.expect_float(&self.emit(&args[0])?, op)?;
+        for arg in &args[1..] {
+            let rhs = self.expect_float(&self.emit(arg)?, op)?;
+            acc = match op {
+                "+." => self
+                    .builder
+                    .build_float_add(acc, rhs, "faddtmp")
+                    .map_err(|e| format!("LLVM build_float_add failed: {}", e))?,
+                "-." => self
+                    .builder
+                    .build_float_sub(acc, rhs, "fsubtmp")
+                    .map_err(|e| format!("LLVM build_float_sub failed: {}", e))?,
+                "*." => self
+                    .builder
+                    .build_float_mul(acc, rhs, "fmultmp")
+                    .map_err(|e| format!("LLVM build_float_mul failed: {}", e))?,
+                "/." => self
+                    .builder
+                    .build_float_div(acc, rhs, "fdivtmp")
+                    .map_err(|e| format!("LLVM build_float_div failed: {}", e))?,
+                _ => unreachable!("operator dispatch checked already"),
+            };
+        }
+        Ok(EmitVal::Float(acc))
+    }
+
+    /// Generate a binary comparison `(op a b)` → `i1`.
+    /// Dispatches on the LHS's value kind: integers use signed
+    /// predicates, floats use ordered predicates (OEQ/OLT/...).
+    /// "Ordered" means NaN compares false, matching the interpreter's
+    /// IEEE-754 semantics.
+    fn gen_cmp(&self, op: &str, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
         if args.len() != 2 {
             return Err(format!(
                 "comparison `{}` requires exactly 2 arguments, got {}",
@@ -305,64 +409,84 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
         }
         let lhs = self.emit(&args[0])?;
         let rhs = self.emit(&args[1])?;
-        let lw = lhs.get_type().get_bit_width();
-        let rw = rhs.get_type().get_bit_width();
-        if lw != rw {
-            return Err(format!(
-                "comparison `{}`: operand width mismatch (i{} vs i{})",
-                op, lw, rw
-            ));
+        match (lhs, rhs) {
+            (EmitVal::Int(l), EmitVal::Int(r)) => {
+                let lw = l.get_type().get_bit_width();
+                let rw = r.get_type().get_bit_width();
+                if lw != rw {
+                    return Err(format!(
+                        "comparison `{}`: operand width mismatch (i{} vs i{})",
+                        op, lw, rw
+                    ));
+                }
+                if lw != 32 && lw != 64 {
+                    return Err(format!(
+                        "comparison `{}` only supports i32/i64 integer operands, got i{}",
+                        op, lw
+                    ));
+                }
+                let pred = match op {
+                    "=" => IntPredicate::EQ,
+                    "<" => IntPredicate::SLT,
+                    ">" => IntPredicate::SGT,
+                    "<=" => IntPredicate::SLE,
+                    ">=" => IntPredicate::SGE,
+                    _ => unreachable!("comparison dispatch checked already"),
+                };
+                let r = self
+                    .builder
+                    .build_int_compare(pred, l, r, "cmptmp")
+                    .map_err(|e| format!("LLVM build_int_compare failed: {}", e))?;
+                Ok(EmitVal::Int(r))
+            }
+            (EmitVal::Float(l), EmitVal::Float(r)) => {
+                let pred = match op {
+                    "=" => FloatPredicate::OEQ,
+                    "<" => FloatPredicate::OLT,
+                    ">" => FloatPredicate::OGT,
+                    "<=" => FloatPredicate::OLE,
+                    ">=" => FloatPredicate::OGE,
+                    _ => unreachable!("comparison dispatch checked already"),
+                };
+                let r = self
+                    .builder
+                    .build_float_compare(pred, l, r, "fcmptmp")
+                    .map_err(|e| format!("LLVM build_float_compare failed: {}", e))?;
+                Ok(EmitVal::Int(r))
+            }
+            (l, r) => Err(format!(
+                "comparison `{}`: cannot compare {} with {}",
+                op,
+                l.type_name(),
+                r.type_name()
+            )),
         }
-        if lw != 32 && lw != 64 {
-            return Err(format!(
-                "comparison `{}` only supports integer operands (i32/i64), got i{}",
-                op, lw
-            ));
-        }
-        let pred = match op {
-            "=" => IntPredicate::EQ,
-            "<" => IntPredicate::SLT,
-            ">" => IntPredicate::SGT,
-            "<=" => IntPredicate::SLE,
-            ">=" => IntPredicate::SGE,
-            _ => unreachable!("comparison dispatch checked already"),
-        };
-        self.builder
-            .build_int_compare(pred, lhs, rhs, "cmptmp")
-            .map_err(|e| format!("LLVM build_int_compare failed: {}", e))
     }
 
     /// Lower `(if c t e)` with a phi at the merge.
-    ///
-    /// Layout:
-    ///   ; current block evaluates `c`, then conditional branch
-    ///   then_bb: <emit t>; br merge
-    ///   else_bb: <emit e>; br merge
-    ///   merge: %r = phi [t_val, then_end], [e_val, else_end]
-    ///
-    /// We capture the *end-of-arm* block (not the start) because each
-    /// arm's emit can itself create new blocks (nested ifs etc.), and
-    /// phi must reference the block that actually fell through to merge.
     fn emit_if(
         &self,
         cond: &Expr,
         then_e: &Expr,
         else_e: &Expr,
-    ) -> Result<IntValue<'ctx>, JitError> {
+    ) -> Result<EmitVal<'ctx>, JitError> {
         let cond_v = self.emit(cond)?;
-        if cond_v.get_type().get_bit_width() != 1 {
-            return Err(format!(
-                "`if` condition must be bool, got i{}",
-                cond_v.get_type().get_bit_width()
-            ));
-        }
+        let cond_int = match cond_v {
+            EmitVal::Int(iv) if iv.get_type().get_bit_width() == 1 => iv,
+            other => {
+                return Err(format!(
+                    "`if` condition must be bool, got {}",
+                    other.type_name()
+                ));
+            }
+        };
 
         let then_bb = self.context.append_basic_block(self.function, "then");
         let else_bb = self.context.append_basic_block(self.function, "else");
         let merge_bb = self.context.append_basic_block(self.function, "ifcont");
 
         self.builder
-            .build_conditional_branch(cond_v, then_bb, else_bb)
+            .build_conditional_branch(cond_int, then_bb, else_bb)
             .map_err(|e| format!("LLVM build_conditional_branch failed: {}", e))?;
 
         // then arm
@@ -381,14 +505,16 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             .build_unconditional_branch(merge_bb)
             .map_err(|e| format!("LLVM build_unconditional_branch failed: {}", e))?;
 
-        // Both arms must produce the same type. The type checker enforces
+        // Both arms must produce the same kind. The type checker enforces
         // this; check defensively.
-        if then_v.get_type() != else_v.get_type() {
+        let then_be = then_v.as_basic_value_enum();
+        let else_be = else_v.as_basic_value_enum();
+        if then_be.get_type() != else_be.get_type() {
             return Err(format!(
-                "`if` branches have different types (i{} vs i{}) — \
+                "`if` branches have different types ({} vs {}) — \
                  the type checker should have caught this",
-                then_v.get_type().get_bit_width(),
-                else_v.get_type().get_bit_width()
+                then_v.type_name(),
+                else_v.type_name()
             ));
         }
 
@@ -396,68 +522,54 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
         self.builder.position_at_end(merge_bb);
         let phi = self
             .builder
-            .build_phi(then_v.get_type(), "iftmp")
+            .build_phi(then_be.get_type(), "iftmp")
             .map_err(|e| format!("LLVM build_phi failed: {}", e))?;
-        phi.add_incoming(&[(&then_v, then_end), (&else_v, else_end)]);
-        Ok(phi.as_basic_value().into_int_value())
+        phi.add_incoming(&[(&then_be, then_end), (&else_be, else_end)]);
+
+        let merged = phi.as_basic_value();
+        Ok(match (then_v, else_v) {
+            (EmitVal::Int(_), _) => EmitVal::Int(merged.into_int_value()),
+            (EmitVal::Float(_), _) => EmitVal::Float(merged.into_float_value()),
+        })
     }
 
     /// Short-circuit `and`. Variadic: `(and a b c)` is left-folded so
-    /// that any false short-circuits to false without evaluating the
-    /// rest. We implement each step as
-    ///   if acc then (eval next) else false
-    /// which the optimizer collapses to a chain of basic blocks anyway,
-    /// so this stays simple.
-    fn gen_and(&self, args: &[Expr]) -> Result<IntValue<'ctx>, JitError> {
+    /// that any false short-circuits to false without evaluating the rest.
+    fn gen_and(&self, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
         if args.is_empty() {
-            // `(and)` is conventionally `true` in Lisp; Rusp's type
-            // checker rejects this anyway, but keep behavior defined.
-            return Ok(self.context.bool_type().const_int(1, false));
+            return Ok(EmitVal::Int(self.context.bool_type().const_int(1, false)));
         }
-        let mut acc = self.emit(&args[0])?;
+        let mut acc = self.expect_bool(&self.emit(&args[0])?, "and")?;
         for arg in &args[1..] {
             acc = self.short_circuit(acc, arg, ShortCircuit::And)?;
         }
-        Ok(acc)
+        Ok(EmitVal::Int(acc))
     }
 
     /// Short-circuit `or`. Mirror of `gen_and`.
-    fn gen_or(&self, args: &[Expr]) -> Result<IntValue<'ctx>, JitError> {
+    fn gen_or(&self, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
         if args.is_empty() {
-            return Ok(self.context.bool_type().const_int(0, false));
+            return Ok(EmitVal::Int(self.context.bool_type().const_int(0, false)));
         }
-        let mut acc = self.emit(&args[0])?;
+        let mut acc = self.expect_bool(&self.emit(&args[0])?, "or")?;
         for arg in &args[1..] {
             acc = self.short_circuit(acc, arg, ShortCircuit::Or)?;
         }
-        Ok(acc)
+        Ok(EmitVal::Int(acc))
     }
 
     /// Lower `acc OP rhs` as a control-flow short-circuit and phi.
-    ///
-    /// And: if acc then rhs else false
-    /// Or:  if acc then true else rhs
     fn short_circuit(
         &self,
         acc: IntValue<'ctx>,
         rhs_expr: &Expr,
         kind: ShortCircuit,
     ) -> Result<IntValue<'ctx>, JitError> {
-        if acc.get_type().get_bit_width() != 1 {
-            return Err(format!(
-                "`{}` operand must be bool, got i{}",
-                kind.name(),
-                acc.get_type().get_bit_width()
-            ));
-        }
-
         let bool_t = self.context.bool_type();
         let eval_bb = self.context.append_basic_block(self.function, kind.eval_label());
         let skip_bb = self.context.append_basic_block(self.function, kind.skip_label());
         let merge_bb = self.context.append_basic_block(self.function, "sccont");
 
-        // Branch direction depends on the operator: for `and`, evaluate
-        // rhs only if acc is true; for `or`, only if acc is false.
         let (then_target, else_target) = match kind {
             ShortCircuit::And => (eval_bb, skip_bb),
             ShortCircuit::Or => (skip_bb, eval_bb),
@@ -466,24 +578,15 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             .build_conditional_branch(acc, then_target, else_target)
             .map_err(|e| format!("LLVM build_conditional_branch failed: {}", e))?;
 
-        // Evaluation block: emit rhs and branch to merge.
         self.builder.position_at_end(eval_bb);
-        let rhs = self.emit(rhs_expr)?;
-        if rhs.get_type().get_bit_width() != 1 {
-            return Err(format!(
-                "`{}` operand must be bool, got i{}",
-                kind.name(),
-                rhs.get_type().get_bit_width()
-            ));
-        }
+        let rhs = self.expect_bool(&self.emit(rhs_expr)?, kind.name())?;
         let eval_end = self.builder.get_insert_block().expect("eval has insert block");
         self.builder
             .build_unconditional_branch(merge_bb)
             .map_err(|e| format!("LLVM build_unconditional_branch failed: {}", e))?;
 
-        // Skip block: short-circuit constant.
         self.builder.position_at_end(skip_bb);
-        let short_v: IntValue<'ctx> = match kind {
+        let short_v = match kind {
             ShortCircuit::And => bool_t.const_int(0, false),
             ShortCircuit::Or => bool_t.const_int(1, false),
         };
@@ -492,7 +595,6 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             .build_unconditional_branch(merge_bb)
             .map_err(|e| format!("LLVM build_unconditional_branch failed: {}", e))?;
 
-        // Merge with phi.
         self.builder.position_at_end(merge_bb);
         let phi = self
             .builder
@@ -502,26 +604,54 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
         Ok(phi.as_basic_value().into_int_value())
     }
 
-    /// `(not b)` → `b XOR 1`. No control flow needed since it always
-    /// evaluates the operand.
-    fn gen_not(&self, args: &[Expr]) -> Result<IntValue<'ctx>, JitError> {
+    /// `(not b)` → `b XOR 1`.
+    fn gen_not(&self, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
         if args.len() != 1 {
             return Err(format!(
                 "`not` requires exactly 1 argument, got {}",
                 args.len()
             ));
         }
-        let v = self.emit(&args[0])?;
-        if v.get_type().get_bit_width() != 1 {
-            return Err(format!(
-                "`not` operand must be bool, got i{}",
-                v.get_type().get_bit_width()
-            ));
-        }
+        let v = self.expect_bool(&self.emit(&args[0])?, "not")?;
         let one = self.context.bool_type().const_int(1, false);
-        self.builder
+        let r = self
+            .builder
             .build_xor(v, one, "nottmp")
-            .map_err(|e| format!("LLVM build_xor failed: {}", e))
+            .map_err(|e| format!("LLVM build_xor failed: {}", e))?;
+        Ok(EmitVal::Int(r))
+    }
+
+    fn expect_int(&self, v: &EmitVal<'ctx>, op: &str) -> Result<IntValue<'ctx>, JitError> {
+        match v {
+            EmitVal::Int(iv) if iv.get_type().get_bit_width() != 1 => Ok(*iv),
+            other => Err(format!(
+                "operator `{}` requires integer operands, got {}",
+                op,
+                other.type_name()
+            )),
+        }
+    }
+
+    fn expect_float(&self, v: &EmitVal<'ctx>, op: &str) -> Result<FloatValue<'ctx>, JitError> {
+        match v {
+            EmitVal::Float(fv) => Ok(*fv),
+            other => Err(format!(
+                "operator `{}` requires float operands, got {}",
+                op,
+                other.type_name()
+            )),
+        }
+    }
+
+    fn expect_bool(&self, v: &EmitVal<'ctx>, op: &str) -> Result<IntValue<'ctx>, JitError> {
+        match v {
+            EmitVal::Int(iv) if iv.get_type().get_bit_width() == 1 => Ok(*iv),
+            other => Err(format!(
+                "operator `{}` operand must be bool, got {}",
+                op,
+                other.type_name()
+            )),
+        }
     }
 }
 

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -1,10 +1,13 @@
-//! Minimal JIT entry point for Step 2: parse → type-check → codegen → run.
+//! Minimal JIT entry point for Steps 2–3: parse → type-check → codegen → run.
 //!
-//! Only i32 literals and i32 arithmetic (`+`, `-`, `*`, `/`) are supported
-//! at this stage. Each call creates its own LLVM `Context` and module,
-//! wraps the input expression in an anonymous `__expr() -> i32` function,
-//! adds the module to a fresh execution engine, and looks up + calls the
-//! function. This keeps lifetimes simple and tests well isolated.
+//! Supports i32/i64 literals and integer arithmetic (`+`, `-`, `*`, `/`).
+//! The expression's leading operand picks the integer width; the type
+//! checker has already validated that all operands share the same width.
+//!
+//! Each call creates its own LLVM `Context` and module, wraps the input
+//! in an anonymous thunk (`__expr() -> T`), JITs it via `ExecutionEngine`,
+//! and looks the function up by name. Per-call Context keeps lifetimes
+//! simple and tests well isolated.
 
 use inkwell::OptimizationLevel;
 use inkwell::builder::Builder;
@@ -23,41 +26,109 @@ pub type JitError = String;
 /// than panicking, so callers can surface a clean message in the REPL.
 pub fn jit_eval_i32(expr: &Expr) -> Result<i32, JitError> {
     let context = Context::create();
+    let result = compile_and_run(&context, expr, IntKind::I32)?;
+    // SAFETY of the cast: the JIT returned an i32 inside a u64 (we trampoline
+    // through u64 to keep one signature for both widths). Truncation is safe.
+    Ok(result as i32)
+}
+
+/// Compile and JIT-run `expr` as an `i64`-returning thunk.
+pub fn jit_eval_i64(expr: &Expr) -> Result<i64, JitError> {
+    let context = Context::create();
+    let result = compile_and_run(&context, expr, IntKind::I64)?;
+    Ok(result as i64)
+}
+
+/// Compile, JIT, and run `__expr` returning a single integer of the
+/// requested width. The actual width affects only the function signature
+/// and the truncation/sign-extension at the boundary; codegen for the
+/// body itself is uniform across i32/i64.
+fn compile_and_run(
+    context: &Context,
+    expr: &Expr,
+    expected: IntKind,
+) -> Result<u64, JitError> {
     let module = context.create_module("rusp_jit");
     let builder = context.create_builder();
 
-    // (1) Define `__expr() -> i32`.
-    let i32_t = context.i32_type();
-    let fn_t = i32_t.fn_type(&[], false);
+    let ret_t = match expected {
+        IntKind::I32 => context.i32_type(),
+        IntKind::I64 => context.i64_type(),
+    };
+    let fn_t = ret_t.fn_type(&[], false);
     let function = module.add_function("__expr", fn_t, None);
     let entry = context.append_basic_block(function, "entry");
     builder.position_at_end(entry);
 
-    // (2) Translate the user expression into a single i32 SSA value.
-    let cg = ExprCg {
-        context: &context,
-        builder: &builder,
-    };
+    let cg = ExprCg { context, builder: &builder };
     let value = cg.emit(expr)?;
+
+    // The codegen body picks the width from the leading operand. Reject
+    // mismatches loudly here so callers debug a width problem at the
+    // boundary rather than misreading bits.
+    let body_kind = IntKind::from_int_value(&value)?;
+    if body_kind != expected {
+        return Err(format!(
+            "JIT requested {} but expression produced {}",
+            expected.name(),
+            body_kind.name()
+        ));
+    }
+
     builder
         .build_return(Some(&value))
         .map_err(|e| format!("LLVM build_return failed: {}", e))?;
 
-    // (3) JIT and run.
-    let engine: ExecutionEngine =
-        module
-            .create_jit_execution_engine(OptimizationLevel::None)
-            .map_err(|e| format!("failed to create JIT execution engine: {}", e))?;
+    let engine: ExecutionEngine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .map_err(|e| format!("failed to create JIT execution engine: {}", e))?;
 
-    // SAFETY: signature `() -> i32` matches what we just emitted, the
-    // module is owned by `engine`, and we drop both before returning.
+    // SAFETY: We just emitted the function with the matching signature and
+    // verified the body's width above. The module is owned by `engine`,
+    // both are dropped at end of scope.
     let result = unsafe {
-        let func = engine
-            .get_function::<unsafe extern "C" fn() -> i32>("__expr")
-            .map_err(|e| format!("failed to look up __expr: {}", e))?;
-        func.call()
+        match expected {
+            IntKind::I32 => {
+                let func = engine
+                    .get_function::<unsafe extern "C" fn() -> i32>("__expr")
+                    .map_err(|e| format!("failed to look up __expr: {}", e))?;
+                func.call() as u64
+            }
+            IntKind::I64 => {
+                let func = engine
+                    .get_function::<unsafe extern "C" fn() -> i64>("__expr")
+                    .map_err(|e| format!("failed to look up __expr: {}", e))?;
+                func.call() as u64
+            }
+        }
     };
     Ok(result)
+}
+
+/// Width tag used to keep i32 and i64 from cross-talking. We don't try to
+/// support implicit widening — the type checker forbids mixing widths in
+/// one expression, so codegen mirrors that contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IntKind {
+    I32,
+    I64,
+}
+
+impl IntKind {
+    fn name(&self) -> &'static str {
+        match self {
+            IntKind::I32 => "i32",
+            IntKind::I64 => "i64",
+        }
+    }
+
+    fn from_int_value(v: &IntValue<'_>) -> Result<Self, JitError> {
+        match v.get_type().get_bit_width() {
+            32 => Ok(IntKind::I32),
+            64 => Ok(IntKind::I64),
+            other => Err(format!("unsupported integer width: i{}", other)),
+        }
+    }
 }
 
 /// Per-invocation codegen helper. Borrows the Context/Module/Builder so
@@ -68,14 +139,19 @@ struct ExprCg<'ctx, 'a> {
 }
 
 impl<'ctx, 'a> ExprCg<'ctx, 'a> {
-    /// Generate IR for `expr`, returning the resulting i32 SSA value.
+    /// Generate IR for `expr`, returning the resulting integer SSA value.
+    /// Width (i32 vs i64) is determined by the first integer literal /
+    /// operand in the form, matching the type checker's rules.
     fn emit(&self, expr: &Expr) -> Result<IntValue<'ctx>, JitError> {
         match expr {
             Expr::Integer32(n) => {
-                // i32 literal — sign-extending the i64 cast is fine for
-                // negative values because const_int treats the source as a
-                // sign-extended u64.
+                // i32 literal — `const_int` reads the bits of the supplied
+                // u64; passing `true` for sign_extend handles negatives.
                 Ok(self.context.i32_type().const_int(*n as u64, true))
+            }
+
+            Expr::Integer64(n) => {
+                Ok(self.context.i64_type().const_int(*n as u64, true))
             }
 
             // Operator forms `(op a b ...)` parse as `Expr::List` with the
@@ -91,12 +167,12 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
                         )),
                     }
                 } else {
-                    Err("--llvm: only operator-headed lists are supported in Step 2".to_string())
+                    Err("--llvm: only operator-headed lists are supported in Step 3".to_string())
                 }
             }
 
-            // `Expr::Call` is what bare `(f x y)` parses to. For Step 2
-            // we only handle the operator forms above, which always come
+            // `Expr::Call` is what bare `(f x y)` parses to. For now we
+            // only handle the operator forms above, which always come
             // through `Expr::List`. Calls land here only for user-defined
             // functions, which Step 7 will enable.
             Expr::Call { .. } => {
@@ -110,8 +186,11 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
         }
     }
 
-    /// Generate `(op arg0 arg1 ...)` for binary i32 arithmetic. Variadic
-    /// in source (`(+ 1 2 3)`) is left-folded.
+    /// Generate `(op arg0 arg1 ...)` for binary integer arithmetic.
+    /// Variadic in source (`(+ 1 2 3)`) is left-folded. Width is taken
+    /// from the first operand; subsequent operands must match. The type
+    /// checker normally guarantees this, so a mismatch here is a bug
+    /// rather than user error.
     fn gen_arith(&self, op: &str, args: &[Expr]) -> Result<IntValue<'ctx>, JitError> {
         if args.len() < 2 {
             return Err(format!(
@@ -122,8 +201,18 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
         }
 
         let mut acc = self.emit(&args[0])?;
+        let acc_width = acc.get_type().get_bit_width();
         for arg in &args[1..] {
             let rhs = self.emit(arg)?;
+            if rhs.get_type().get_bit_width() != acc_width {
+                return Err(format!(
+                    "operator `{}`: operand width mismatch (i{} vs i{}) — \
+                     this is a codegen invariant that the type checker should have caught",
+                    op,
+                    acc_width,
+                    rhs.get_type().get_bit_width()
+                ));
+            }
             acc = match op {
                 "+" => self
                     .builder

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -132,7 +132,7 @@ fn split_program(forms: &[Expr]) -> Result<(Vec<&Expr>, &Expr), JitError> {
 /// recursive calls resolve. Parameters become entries in the body's
 /// `env`. The body must produce a value matching the declared return
 /// type.
-fn emit_defn<'ctx>(
+pub(crate) fn emit_defn<'ctx>(
     context: &'ctx Context,
     module: &Module<'ctx>,
     builder: &Builder<'ctx>,

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -1,4 +1,4 @@
-//! Minimal JIT entry point for Steps 2–5: parse → type-check → codegen → run.
+//! Minimal JIT entry point for Steps 2–6: parse → type-check → codegen → run.
 //!
 //! Supports:
 //! - i32/i64 literals and integer arithmetic (`+`, `-`, `*`, `/`)
@@ -7,6 +7,7 @@
 //! - comparison (`=`, `<`, `>`, `<=`, `>=`) on i32, i64, and f64
 //! - `if` (with phi-merge)
 //! - `and`/`or`/`not` (short-circuit for `and`/`or`, xor for `not`)
+//! - `let`-in (lexical bindings via a flat HashMap; SSA values, no alloca)
 //!
 //! Integer arithmetic / comparison forms infer their width from the
 //! leading operand; the type checker has already enforced that every
@@ -24,6 +25,8 @@ use inkwell::execution_engine::ExecutionEngine;
 use inkwell::types::{BasicType, BasicTypeEnum};
 use inkwell::values::{BasicValue, BasicValueEnum, FloatValue, FunctionValue, IntValue};
 use inkwell::{FloatPredicate, IntPredicate};
+
+use std::collections::HashMap;
 
 use crate::ast::Expr;
 
@@ -131,7 +134,12 @@ fn compile_and_run(
     let entry = context.append_basic_block(function, "entry");
     builder.position_at_end(entry);
 
-    let cg = ExprCg { context, builder: &builder, function };
+    let mut cg = ExprCg {
+        context,
+        builder: &builder,
+        function,
+        env: HashMap::new(),
+    };
     let value = cg.emit(expr)?;
 
     // Width / kind validation: surface mismatches loudly so callers debug
@@ -245,11 +253,16 @@ struct ExprCg<'ctx, 'a> {
     context: &'ctx Context,
     builder: &'a Builder<'ctx>,
     function: FunctionValue<'ctx>,
+    /// Lexical environment for `let`-bound names. Flat (no parent
+    /// chain) because rebinding via shadowing is implemented by
+    /// snapshotting the displaced entry and restoring it after the
+    /// body. SSA-style: each binding maps to a value, not an alloca.
+    env: HashMap<String, EmitVal<'ctx>>,
 }
 
 impl<'ctx, 'a> ExprCg<'ctx, 'a> {
     /// Generate IR for `expr`, returning the resulting SSA value.
-    fn emit(&self, expr: &Expr) -> Result<EmitVal<'ctx>, JitError> {
+    fn emit(&mut self, expr: &Expr) -> Result<EmitVal<'ctx>, JitError> {
         match expr {
             Expr::Integer32(n) => Ok(EmitVal::Int(
                 self.context.i32_type().const_int(*n as u64, true),
@@ -264,6 +277,18 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             Expr::Bool(b) => Ok(EmitVal::Int(
                 self.context.bool_type().const_int(u64::from(*b), false),
             )),
+
+            // Lexical lookup. Operator symbols (e.g. `+`, `<`) never
+            // reach here because they appear as the head of a List
+            // and are handled there; only `let`-bound user names do.
+            Expr::Symbol(name) => self.env.get(name).copied().ok_or_else(|| {
+                format!("--llvm: undefined variable `{}`", name)
+            }),
+
+            // `let-in`: bind value, emit body in extended env, restore.
+            // Top-level `let` (no body) doesn't make sense for a
+            // single-thunk JIT and is rejected here.
+            Expr::Let { name, value, body, .. } => self.emit_let(name, value, body.as_deref()),
 
             // `if` is its own AST node (not a List with "if" symbol).
             Expr::If { condition, then_branch, else_branch } => {
@@ -306,7 +331,7 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
     /// Generate `(op arg0 arg1 ...)` for binary integer arithmetic.
     /// Variadic in source (`(+ 1 2 3)`) is left-folded. Width is taken
     /// from the first operand.
-    fn gen_int_arith(&self, op: &str, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
+    fn gen_int_arith(&mut self, op: &str, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
         if args.len() < 2 {
             return Err(format!(
                 "operator `{}` requires at least 2 arguments, got {}",
@@ -314,7 +339,8 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
                 args.len()
             ));
         }
-        let mut acc = self.expect_int(&self.emit(&args[0])?, op)?;
+        let first = self.emit(&args[0])?;
+        let mut acc = self.expect_int(&first, op)?;
         let acc_width = acc.get_type().get_bit_width();
         if acc_width != 32 && acc_width != 64 {
             return Err(format!(
@@ -323,7 +349,8 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             ));
         }
         for arg in &args[1..] {
-            let rhs = self.expect_int(&self.emit(arg)?, op)?;
+            let rhs_v = self.emit(arg)?;
+            let rhs = self.expect_int(&rhs_v, op)?;
             if rhs.get_type().get_bit_width() != acc_width {
                 return Err(format!(
                     "operator `{}`: operand width mismatch (i{} vs i{}) — \
@@ -360,7 +387,7 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
     /// Mirrors `gen_int_arith`. Rusp's float ops are syntactically
     /// distinct from int ones (`+.` vs `+`), so the type checker has
     /// already guaranteed every operand is f64.
-    fn gen_float_arith(&self, op: &str, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
+    fn gen_float_arith(&mut self, op: &str, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
         if args.len() < 2 {
             return Err(format!(
                 "operator `{}` requires at least 2 arguments, got {}",
@@ -368,9 +395,11 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
                 args.len()
             ));
         }
-        let mut acc = self.expect_float(&self.emit(&args[0])?, op)?;
+        let first = self.emit(&args[0])?;
+        let mut acc = self.expect_float(&first, op)?;
         for arg in &args[1..] {
-            let rhs = self.expect_float(&self.emit(arg)?, op)?;
+            let rhs_v = self.emit(arg)?;
+            let rhs = self.expect_float(&rhs_v, op)?;
             acc = match op {
                 "+." => self
                     .builder
@@ -399,7 +428,7 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
     /// predicates, floats use ordered predicates (OEQ/OLT/...).
     /// "Ordered" means NaN compares false, matching the interpreter's
     /// IEEE-754 semantics.
-    fn gen_cmp(&self, op: &str, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
+    fn gen_cmp(&mut self, op: &str, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
         if args.len() != 2 {
             return Err(format!(
                 "comparison `{}` requires exactly 2 arguments, got {}",
@@ -465,7 +494,7 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
 
     /// Lower `(if c t e)` with a phi at the merge.
     fn emit_if(
-        &self,
+        &mut self,
         cond: &Expr,
         then_e: &Expr,
         else_e: &Expr,
@@ -533,13 +562,44 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
         })
     }
 
+    /// `(let name value body)` — let-in. Bind `name` to the value of
+    /// `value`, emit `body` with that binding visible, then restore the
+    /// previous binding (or remove it). Top-level `let` (no body) is
+    /// rejected here because the JIT compiles a single expression.
+    ///
+    /// Shadowing is supported: if `name` already exists, save the old
+    /// value before inserting and put it back after the body.
+    fn emit_let(
+        &mut self,
+        name: &str,
+        value: &Expr,
+        body: Option<&Expr>,
+    ) -> Result<EmitVal<'ctx>, JitError> {
+        let body = body.ok_or_else(|| {
+            "--llvm: top-level `let` (without body) is not supported in JIT mode".to_string()
+        })?;
+        let val = self.emit(value)?;
+        let prev = self.env.insert(name.to_string(), val);
+        let result = self.emit(body);
+        match prev {
+            Some(old) => {
+                self.env.insert(name.to_string(), old);
+            }
+            None => {
+                self.env.remove(name);
+            }
+        }
+        result
+    }
+
     /// Short-circuit `and`. Variadic: `(and a b c)` is left-folded so
     /// that any false short-circuits to false without evaluating the rest.
-    fn gen_and(&self, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
+    fn gen_and(&mut self, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
         if args.is_empty() {
             return Ok(EmitVal::Int(self.context.bool_type().const_int(1, false)));
         }
-        let mut acc = self.expect_bool(&self.emit(&args[0])?, "and")?;
+        let first = self.emit(&args[0])?;
+        let mut acc = self.expect_bool(&first, "and")?;
         for arg in &args[1..] {
             acc = self.short_circuit(acc, arg, ShortCircuit::And)?;
         }
@@ -547,11 +607,12 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
     }
 
     /// Short-circuit `or`. Mirror of `gen_and`.
-    fn gen_or(&self, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
+    fn gen_or(&mut self, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
         if args.is_empty() {
             return Ok(EmitVal::Int(self.context.bool_type().const_int(0, false)));
         }
-        let mut acc = self.expect_bool(&self.emit(&args[0])?, "or")?;
+        let first = self.emit(&args[0])?;
+        let mut acc = self.expect_bool(&first, "or")?;
         for arg in &args[1..] {
             acc = self.short_circuit(acc, arg, ShortCircuit::Or)?;
         }
@@ -560,7 +621,7 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
 
     /// Lower `acc OP rhs` as a control-flow short-circuit and phi.
     fn short_circuit(
-        &self,
+        &mut self,
         acc: IntValue<'ctx>,
         rhs_expr: &Expr,
         kind: ShortCircuit,
@@ -579,7 +640,8 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             .map_err(|e| format!("LLVM build_conditional_branch failed: {}", e))?;
 
         self.builder.position_at_end(eval_bb);
-        let rhs = self.expect_bool(&self.emit(rhs_expr)?, kind.name())?;
+        let rhs_v = self.emit(rhs_expr)?;
+        let rhs = self.expect_bool(&rhs_v, kind.name())?;
         let eval_end = self.builder.get_insert_block().expect("eval has insert block");
         self.builder
             .build_unconditional_branch(merge_bb)
@@ -605,14 +667,15 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
     }
 
     /// `(not b)` → `b XOR 1`.
-    fn gen_not(&self, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
+    fn gen_not(&mut self, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
         if args.len() != 1 {
             return Err(format!(
                 "`not` requires exactly 1 argument, got {}",
                 args.len()
             ));
         }
-        let v = self.expect_bool(&self.emit(&args[0])?, "not")?;
+        let v_e = self.emit(&args[0])?;
+        let v = self.expect_bool(&v_e, "not")?;
         let one = self.context.bool_type().const_int(1, false);
         let r = self
             .builder

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -1,8 +1,15 @@
-//! Minimal JIT entry point for Steps 2–3: parse → type-check → codegen → run.
+//! Minimal JIT entry point for Steps 2–4: parse → type-check → codegen → run.
 //!
-//! Supports i32/i64 literals and integer arithmetic (`+`, `-`, `*`, `/`).
-//! The expression's leading operand picks the integer width; the type
-//! checker has already validated that all operands share the same width.
+//! Supports:
+//! - i32/i64 literals and integer arithmetic (`+`, `-`, `*`, `/`)
+//! - bool literals
+//! - integer comparison (`=`, `<`, `>`, `<=`, `>=`) — i32 and i64
+//! - `if` (with phi-merge)
+//! - `and`/`or`/`not` (short-circuit for `and`/`or`, xor for `not`)
+//!
+//! The integer-arithmetic / comparison forms infer their width from the
+//! leading operand; the type checker has already enforced that every
+//! operand of one form shares that width.
 //!
 //! Each call creates its own LLVM `Context` and module, wraps the input
 //! in an anonymous thunk (`__expr() -> T`), JITs it via `ExecutionEngine`,
@@ -13,7 +20,8 @@ use inkwell::OptimizationLevel;
 use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::execution_engine::ExecutionEngine;
-use inkwell::values::IntValue;
+use inkwell::values::{FunctionValue, IntValue};
+use inkwell::{IntPredicate};
 
 use crate::ast::Expr;
 
@@ -26,7 +34,7 @@ pub type JitError = String;
 /// than panicking, so callers can surface a clean message in the REPL.
 pub fn jit_eval_i32(expr: &Expr) -> Result<i32, JitError> {
     let context = Context::create();
-    let result = compile_and_run(&context, expr, IntKind::I32)?;
+    let result = compile_and_run(&context, expr, ReturnKind::I32)?;
     // SAFETY of the cast: the JIT returned an i32 inside a u64 (we trampoline
     // through u64 to keep one signature for both widths). Truncation is safe.
     Ok(result as i32)
@@ -35,38 +43,70 @@ pub fn jit_eval_i32(expr: &Expr) -> Result<i32, JitError> {
 /// Compile and JIT-run `expr` as an `i64`-returning thunk.
 pub fn jit_eval_i64(expr: &Expr) -> Result<i64, JitError> {
     let context = Context::create();
-    let result = compile_and_run(&context, expr, IntKind::I64)?;
+    let result = compile_and_run(&context, expr, ReturnKind::I64)?;
     Ok(result as i64)
 }
 
-/// Compile, JIT, and run `__expr` returning a single integer of the
-/// requested width. The actual width affects only the function signature
-/// and the truncation/sign-extension at the boundary; codegen for the
-/// body itself is uniform across i32/i64.
+/// Compile and JIT-run `expr` as a `bool`-returning thunk.
+///
+/// LLVM `i1` is zero-extended to `u8` at the FFI boundary because the
+/// C ABI does not specify a layout for `i1`; receiving it as `u8` and
+/// comparing against zero is portable and is what every other inkwell
+/// example does too.
+pub fn jit_eval_bool(expr: &Expr) -> Result<bool, JitError> {
+    let context = Context::create();
+    let result = compile_and_run(&context, expr, ReturnKind::Bool)?;
+    Ok(result != 0)
+}
+
+/// What the top-level thunk should return. Determines the function
+/// signature we emit and the cast applied at the FFI boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReturnKind {
+    I32,
+    I64,
+    Bool,
+}
+
+impl ReturnKind {
+    fn name(&self) -> &'static str {
+        match self {
+            ReturnKind::I32 => "i32",
+            ReturnKind::I64 => "i64",
+            ReturnKind::Bool => "bool",
+        }
+    }
+}
+
+/// Compile, JIT, and run `__expr` returning a single integer-shaped
+/// value of the requested kind. The actual width affects only the
+/// function signature and the truncation/zero-extension at the
+/// boundary; codegen for the body itself dispatches on the value's
+/// own LLVM type.
 fn compile_and_run(
     context: &Context,
     expr: &Expr,
-    expected: IntKind,
+    expected: ReturnKind,
 ) -> Result<u64, JitError> {
     let module = context.create_module("rusp_jit");
     let builder = context.create_builder();
 
     let ret_t = match expected {
-        IntKind::I32 => context.i32_type(),
-        IntKind::I64 => context.i64_type(),
+        ReturnKind::I32 => context.i32_type(),
+        ReturnKind::I64 => context.i64_type(),
+        ReturnKind::Bool => context.bool_type(),
     };
     let fn_t = ret_t.fn_type(&[], false);
     let function = module.add_function("__expr", fn_t, None);
     let entry = context.append_basic_block(function, "entry");
     builder.position_at_end(entry);
 
-    let cg = ExprCg { context, builder: &builder };
+    let cg = ExprCg { context, builder: &builder, function };
     let value = cg.emit(expr)?;
 
-    // The codegen body picks the width from the leading operand. Reject
-    // mismatches loudly here so callers debug a width problem at the
-    // boundary rather than misreading bits.
-    let body_kind = IntKind::from_int_value(&value)?;
+    // Width / kind validation: surface mismatches loudly so callers debug
+    // a width problem at the boundary rather than misreading bits.
+    let body_kind = ReturnKind::from_int_value(&value)?;
     if body_kind != expected {
         return Err(format!(
             "JIT requested {} but expression produced {}",
@@ -88,15 +128,22 @@ fn compile_and_run(
     // both are dropped at end of scope.
     let result = unsafe {
         match expected {
-            IntKind::I32 => {
+            ReturnKind::I32 => {
                 let func = engine
                     .get_function::<unsafe extern "C" fn() -> i32>("__expr")
                     .map_err(|e| format!("failed to look up __expr: {}", e))?;
                 func.call() as u64
             }
-            IntKind::I64 => {
+            ReturnKind::I64 => {
                 let func = engine
                     .get_function::<unsafe extern "C" fn() -> i64>("__expr")
+                    .map_err(|e| format!("failed to look up __expr: {}", e))?;
+                func.call() as u64
+            }
+            ReturnKind::Bool => {
+                // i1 → u8 at the boundary (see jit_eval_bool).
+                let func = engine
+                    .get_function::<unsafe extern "C" fn() -> u8>("__expr")
                     .map_err(|e| format!("failed to look up __expr: {}", e))?;
                 func.call() as u64
             }
@@ -105,43 +152,31 @@ fn compile_and_run(
     Ok(result)
 }
 
-/// Width tag used to keep i32 and i64 from cross-talking. We don't try to
-/// support implicit widening — the type checker forbids mixing widths in
-/// one expression, so codegen mirrors that contract.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum IntKind {
-    I32,
-    I64,
-}
-
-impl IntKind {
-    fn name(&self) -> &'static str {
-        match self {
-            IntKind::I32 => "i32",
-            IntKind::I64 => "i64",
-        }
-    }
-
+impl ReturnKind {
+    /// Map the bit-width of the body's SSA value to the matching ReturnKind.
+    /// i1 → Bool, i32 → I32, i64 → I64. Anything else is unsupported here.
     fn from_int_value(v: &IntValue<'_>) -> Result<Self, JitError> {
         match v.get_type().get_bit_width() {
-            32 => Ok(IntKind::I32),
-            64 => Ok(IntKind::I64),
+            1 => Ok(ReturnKind::Bool),
+            32 => Ok(ReturnKind::I32),
+            64 => Ok(ReturnKind::I64),
             other => Err(format!("unsupported integer width: i{}", other)),
         }
     }
 }
 
 /// Per-invocation codegen helper. Borrows the Context/Module/Builder so
-/// that 'ctx flows through cleanly.
+/// that 'ctx flows through cleanly. Carries the enclosing function so
+/// `if` / short-circuit forms can append fresh basic blocks.
 struct ExprCg<'ctx, 'a> {
     context: &'ctx Context,
     builder: &'a Builder<'ctx>,
+    function: FunctionValue<'ctx>,
 }
 
 impl<'ctx, 'a> ExprCg<'ctx, 'a> {
-    /// Generate IR for `expr`, returning the resulting integer SSA value.
-    /// Width (i32 vs i64) is determined by the first integer literal /
-    /// operand in the form, matching the type checker's rules.
+    /// Generate IR for `expr`, returning the resulting integer SSA value
+    /// (treating `bool` as `i1`).
     fn emit(&self, expr: &Expr) -> Result<IntValue<'ctx>, JitError> {
         match expr {
             Expr::Integer32(n) => {
@@ -154,27 +189,42 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
                 Ok(self.context.i64_type().const_int(*n as u64, true))
             }
 
+            Expr::Bool(b) => {
+                Ok(self.context.bool_type().const_int(u64::from(*b), false))
+            }
+
+            // `if` is its own AST node (not a List with "if" symbol).
+            // Emit cond → conditional branch into then/else blocks → phi
+            // in a merge block. This is the textbook lowering, taken
+            // straight from the Kaleidoscope tutorial.
+            Expr::If { condition, then_branch, else_branch } => {
+                self.emit_if(condition, then_branch, else_branch)
+            }
+
             // Operator forms `(op a b ...)` parse as `Expr::List` with the
-            // operator symbol at position 0. We dispatch on the symbol and
-            // hand off to `gen_arith`.
+            // operator symbol at position 0. Dispatch on the symbol.
             Expr::List(exprs) if !exprs.is_empty() => {
                 if let Expr::Symbol(op) = &exprs[0] {
+                    let args = &exprs[1..];
                     match op.as_str() {
-                        "+" | "-" | "*" | "/" => self.gen_arith(op, &exprs[1..]),
+                        "+" | "-" | "*" | "/" => self.gen_arith(op, args),
+                        "=" | "<" | ">" | "<=" | ">=" => self.gen_cmp(op, args),
+                        "and" => self.gen_and(args),
+                        "or" => self.gen_or(args),
+                        "not" => self.gen_not(args),
                         other => Err(format!(
                             "--llvm: operator `{}` not supported yet",
                             other
                         )),
                     }
                 } else {
-                    Err("--llvm: only operator-headed lists are supported in Step 3".to_string())
+                    Err("--llvm: only operator-headed lists are supported in Step 4".to_string())
                 }
             }
 
             // `Expr::Call` is what bare `(f x y)` parses to. For now we
-            // only handle the operator forms above, which always come
-            // through `Expr::List`. Calls land here only for user-defined
-            // functions, which Step 7 will enable.
+            // only handle the operator forms above. Calls land here only
+            // for user-defined functions, which Step 7 will enable.
             Expr::Call { .. } => {
                 Err("--llvm: function calls are not supported yet (Step 7)".to_string())
             }
@@ -202,6 +252,12 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
 
         let mut acc = self.emit(&args[0])?;
         let acc_width = acc.get_type().get_bit_width();
+        if acc_width != 32 && acc_width != 64 {
+            return Err(format!(
+                "operator `{}` requires integer operands, got i{}",
+                op, acc_width
+            ));
+        }
         for arg in &args[1..] {
             let rhs = self.emit(arg)?;
             if rhs.get_type().get_bit_width() != acc_width {
@@ -234,5 +290,266 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             };
         }
         Ok(acc)
+    }
+
+    /// Generate a binary integer comparison `(op a b)`. Result is `i1`.
+    /// Comparisons in Rusp are strictly binary (the type checker rejects
+    /// arity != 2), so we don't try to fold variadic forms.
+    fn gen_cmp(&self, op: &str, args: &[Expr]) -> Result<IntValue<'ctx>, JitError> {
+        if args.len() != 2 {
+            return Err(format!(
+                "comparison `{}` requires exactly 2 arguments, got {}",
+                op,
+                args.len()
+            ));
+        }
+        let lhs = self.emit(&args[0])?;
+        let rhs = self.emit(&args[1])?;
+        let lw = lhs.get_type().get_bit_width();
+        let rw = rhs.get_type().get_bit_width();
+        if lw != rw {
+            return Err(format!(
+                "comparison `{}`: operand width mismatch (i{} vs i{})",
+                op, lw, rw
+            ));
+        }
+        if lw != 32 && lw != 64 {
+            return Err(format!(
+                "comparison `{}` only supports integer operands (i32/i64), got i{}",
+                op, lw
+            ));
+        }
+        let pred = match op {
+            "=" => IntPredicate::EQ,
+            "<" => IntPredicate::SLT,
+            ">" => IntPredicate::SGT,
+            "<=" => IntPredicate::SLE,
+            ">=" => IntPredicate::SGE,
+            _ => unreachable!("comparison dispatch checked already"),
+        };
+        self.builder
+            .build_int_compare(pred, lhs, rhs, "cmptmp")
+            .map_err(|e| format!("LLVM build_int_compare failed: {}", e))
+    }
+
+    /// Lower `(if c t e)` with a phi at the merge.
+    ///
+    /// Layout:
+    ///   ; current block evaluates `c`, then conditional branch
+    ///   then_bb: <emit t>; br merge
+    ///   else_bb: <emit e>; br merge
+    ///   merge: %r = phi [t_val, then_end], [e_val, else_end]
+    ///
+    /// We capture the *end-of-arm* block (not the start) because each
+    /// arm's emit can itself create new blocks (nested ifs etc.), and
+    /// phi must reference the block that actually fell through to merge.
+    fn emit_if(
+        &self,
+        cond: &Expr,
+        then_e: &Expr,
+        else_e: &Expr,
+    ) -> Result<IntValue<'ctx>, JitError> {
+        let cond_v = self.emit(cond)?;
+        if cond_v.get_type().get_bit_width() != 1 {
+            return Err(format!(
+                "`if` condition must be bool, got i{}",
+                cond_v.get_type().get_bit_width()
+            ));
+        }
+
+        let then_bb = self.context.append_basic_block(self.function, "then");
+        let else_bb = self.context.append_basic_block(self.function, "else");
+        let merge_bb = self.context.append_basic_block(self.function, "ifcont");
+
+        self.builder
+            .build_conditional_branch(cond_v, then_bb, else_bb)
+            .map_err(|e| format!("LLVM build_conditional_branch failed: {}", e))?;
+
+        // then arm
+        self.builder.position_at_end(then_bb);
+        let then_v = self.emit(then_e)?;
+        let then_end = self.builder.get_insert_block().expect("then arm has insert block");
+        self.builder
+            .build_unconditional_branch(merge_bb)
+            .map_err(|e| format!("LLVM build_unconditional_branch failed: {}", e))?;
+
+        // else arm
+        self.builder.position_at_end(else_bb);
+        let else_v = self.emit(else_e)?;
+        let else_end = self.builder.get_insert_block().expect("else arm has insert block");
+        self.builder
+            .build_unconditional_branch(merge_bb)
+            .map_err(|e| format!("LLVM build_unconditional_branch failed: {}", e))?;
+
+        // Both arms must produce the same type. The type checker enforces
+        // this; check defensively.
+        if then_v.get_type() != else_v.get_type() {
+            return Err(format!(
+                "`if` branches have different types (i{} vs i{}) — \
+                 the type checker should have caught this",
+                then_v.get_type().get_bit_width(),
+                else_v.get_type().get_bit_width()
+            ));
+        }
+
+        // merge with phi
+        self.builder.position_at_end(merge_bb);
+        let phi = self
+            .builder
+            .build_phi(then_v.get_type(), "iftmp")
+            .map_err(|e| format!("LLVM build_phi failed: {}", e))?;
+        phi.add_incoming(&[(&then_v, then_end), (&else_v, else_end)]);
+        Ok(phi.as_basic_value().into_int_value())
+    }
+
+    /// Short-circuit `and`. Variadic: `(and a b c)` is left-folded so
+    /// that any false short-circuits to false without evaluating the
+    /// rest. We implement each step as
+    ///   if acc then (eval next) else false
+    /// which the optimizer collapses to a chain of basic blocks anyway,
+    /// so this stays simple.
+    fn gen_and(&self, args: &[Expr]) -> Result<IntValue<'ctx>, JitError> {
+        if args.is_empty() {
+            // `(and)` is conventionally `true` in Lisp; Rusp's type
+            // checker rejects this anyway, but keep behavior defined.
+            return Ok(self.context.bool_type().const_int(1, false));
+        }
+        let mut acc = self.emit(&args[0])?;
+        for arg in &args[1..] {
+            acc = self.short_circuit(acc, arg, ShortCircuit::And)?;
+        }
+        Ok(acc)
+    }
+
+    /// Short-circuit `or`. Mirror of `gen_and`.
+    fn gen_or(&self, args: &[Expr]) -> Result<IntValue<'ctx>, JitError> {
+        if args.is_empty() {
+            return Ok(self.context.bool_type().const_int(0, false));
+        }
+        let mut acc = self.emit(&args[0])?;
+        for arg in &args[1..] {
+            acc = self.short_circuit(acc, arg, ShortCircuit::Or)?;
+        }
+        Ok(acc)
+    }
+
+    /// Lower `acc OP rhs` as a control-flow short-circuit and phi.
+    ///
+    /// And: if acc then rhs else false
+    /// Or:  if acc then true else rhs
+    fn short_circuit(
+        &self,
+        acc: IntValue<'ctx>,
+        rhs_expr: &Expr,
+        kind: ShortCircuit,
+    ) -> Result<IntValue<'ctx>, JitError> {
+        if acc.get_type().get_bit_width() != 1 {
+            return Err(format!(
+                "`{}` operand must be bool, got i{}",
+                kind.name(),
+                acc.get_type().get_bit_width()
+            ));
+        }
+
+        let bool_t = self.context.bool_type();
+        let eval_bb = self.context.append_basic_block(self.function, kind.eval_label());
+        let skip_bb = self.context.append_basic_block(self.function, kind.skip_label());
+        let merge_bb = self.context.append_basic_block(self.function, "sccont");
+
+        // Branch direction depends on the operator: for `and`, evaluate
+        // rhs only if acc is true; for `or`, only if acc is false.
+        let (then_target, else_target) = match kind {
+            ShortCircuit::And => (eval_bb, skip_bb),
+            ShortCircuit::Or => (skip_bb, eval_bb),
+        };
+        self.builder
+            .build_conditional_branch(acc, then_target, else_target)
+            .map_err(|e| format!("LLVM build_conditional_branch failed: {}", e))?;
+
+        // Evaluation block: emit rhs and branch to merge.
+        self.builder.position_at_end(eval_bb);
+        let rhs = self.emit(rhs_expr)?;
+        if rhs.get_type().get_bit_width() != 1 {
+            return Err(format!(
+                "`{}` operand must be bool, got i{}",
+                kind.name(),
+                rhs.get_type().get_bit_width()
+            ));
+        }
+        let eval_end = self.builder.get_insert_block().expect("eval has insert block");
+        self.builder
+            .build_unconditional_branch(merge_bb)
+            .map_err(|e| format!("LLVM build_unconditional_branch failed: {}", e))?;
+
+        // Skip block: short-circuit constant.
+        self.builder.position_at_end(skip_bb);
+        let short_v: IntValue<'ctx> = match kind {
+            ShortCircuit::And => bool_t.const_int(0, false),
+            ShortCircuit::Or => bool_t.const_int(1, false),
+        };
+        let skip_end = self.builder.get_insert_block().expect("skip has insert block");
+        self.builder
+            .build_unconditional_branch(merge_bb)
+            .map_err(|e| format!("LLVM build_unconditional_branch failed: {}", e))?;
+
+        // Merge with phi.
+        self.builder.position_at_end(merge_bb);
+        let phi = self
+            .builder
+            .build_phi(bool_t, "sctmp")
+            .map_err(|e| format!("LLVM build_phi failed: {}", e))?;
+        phi.add_incoming(&[(&rhs, eval_end), (&short_v, skip_end)]);
+        Ok(phi.as_basic_value().into_int_value())
+    }
+
+    /// `(not b)` → `b XOR 1`. No control flow needed since it always
+    /// evaluates the operand.
+    fn gen_not(&self, args: &[Expr]) -> Result<IntValue<'ctx>, JitError> {
+        if args.len() != 1 {
+            return Err(format!(
+                "`not` requires exactly 1 argument, got {}",
+                args.len()
+            ));
+        }
+        let v = self.emit(&args[0])?;
+        if v.get_type().get_bit_width() != 1 {
+            return Err(format!(
+                "`not` operand must be bool, got i{}",
+                v.get_type().get_bit_width()
+            ));
+        }
+        let one = self.context.bool_type().const_int(1, false);
+        self.builder
+            .build_xor(v, one, "nottmp")
+            .map_err(|e| format!("LLVM build_xor failed: {}", e))
+    }
+}
+
+/// Internal tag for `short_circuit` so it can pick branch direction and
+/// short-circuit constant without two near-duplicate methods.
+#[derive(Debug, Clone, Copy)]
+enum ShortCircuit {
+    And,
+    Or,
+}
+
+impl ShortCircuit {
+    fn name(&self) -> &'static str {
+        match self {
+            ShortCircuit::And => "and",
+            ShortCircuit::Or => "or",
+        }
+    }
+    fn eval_label(&self) -> &'static str {
+        match self {
+            ShortCircuit::And => "and_eval",
+            ShortCircuit::Or => "or_eval",
+        }
+    }
+    fn skip_label(&self) -> &'static str {
+        match self {
+            ShortCircuit::And => "and_skip",
+            ShortCircuit::Or => "or_skip",
+        }
     }
 }

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -1,4 +1,4 @@
-//! Minimal JIT entry point for Steps 2–7: parse → type-check → codegen → run.
+//! Minimal JIT entry point for Steps 2–8: parse → type-check → codegen → run.
 //!
 //! Supports:
 //! - i32/i64 literals and integer arithmetic (`+`, `-`, `*`, `/`)
@@ -9,6 +9,7 @@
 //! - `and`/`or`/`not` (short-circuit for `and`/`or`, xor for `not`)
 //! - `let`-in (lexical bindings via a flat HashMap; SSA values, no alloca)
 //! - `defn` + `(f x y)` calls, including direct recursion
+//! - `(fn [...] body)` capture-free lambdas — bound via `let` and called by name
 //!
 //! Integer arithmetic / comparison forms infer their width from the
 //! leading operand; the type checker has already enforced that every
@@ -30,6 +31,7 @@ use inkwell::values::{
 };
 use inkwell::{FloatPredicate, IntPredicate};
 
+use std::cell::Cell;
 use std::collections::HashMap;
 
 use crate::ast::{Expr, Type};
@@ -135,6 +137,7 @@ fn emit_defn<'ctx>(
     module: &Module<'ctx>,
     builder: &Builder<'ctx>,
     functions: &mut HashMap<String, FunctionValue<'ctx>>,
+    lambda_counter: &Cell<u32>,
     expr: &Expr,
 ) -> Result<(), JitError> {
     let Expr::Defn { name, params, return_type, body } = expr else {
@@ -166,15 +169,20 @@ fn emit_defn<'ctx>(
 
     let mut cg = ExprCg {
         context,
+        module,
         builder,
         function,
         env,
         functions: functions.clone(),
+        lambda_counter,
     };
     let body_val = cg.emit(body)?;
 
-    // Body's kind must agree with the declared return type.
-    let body_basic = body_val.as_basic_value_enum();
+    // Body's kind must agree with the declared return type. FuncRef
+    // can't appear here because its `as_basic_value_enum()` errors out.
+    let body_basic = body_val.as_basic_value_enum().map_err(|e| {
+        format!("defn `{}`: cannot return a function value from a defn body: {}", name, e)
+    })?;
     if body_basic.get_type() != ret_basic {
         return Err(format!(
             "defn `{}`: body type {} doesn't match declared return type",
@@ -192,6 +200,12 @@ fn emit_defn<'ctx>(
             .build_return(Some(&fv as &dyn BasicValue))
             .map(|_| ())
             .map_err(|e| format!("LLVM build_return failed: {}", e))?,
+        EmitVal::FuncRef(_) => {
+            return Err(format!(
+                "defn `{}`: cannot return a function value from a defn body",
+                name
+            ));
+        }
     };
 
     // Functions discovered while emitting this body (none for now,
@@ -294,8 +308,9 @@ fn compile_program_and_run(
     // registered in `functions` *before* its body is emitted so that
     // recursive self-calls resolve.
     let mut functions: HashMap<String, FunctionValue<'_>> = HashMap::new();
+    let lambda_counter: Cell<u32> = Cell::new(0);
     for d in &defns {
-        emit_defn(context, &module, &builder, &mut functions, d)?;
+        emit_defn(context, &module, &builder, &mut functions, &lambda_counter, d)?;
     }
 
     // Now emit the top-level thunk for the final expression.
@@ -312,10 +327,12 @@ fn compile_program_and_run(
 
     let mut cg = ExprCg {
         context,
+        module: &module,
         builder: &builder,
         function,
         env: HashMap::new(),
         functions,
+        lambda_counter: &lambda_counter,
     };
     let value = cg.emit(expr)?;
 
@@ -339,6 +356,12 @@ fn compile_program_and_run(
             .build_return(Some(&fv as &dyn BasicValue))
             .map(|_| ())
             .map_err(|e| format!("LLVM build_return failed: {}", e))?,
+        EmitVal::FuncRef(_) => {
+            // Already rejected by `return_kind()` above; this is defensive.
+            return Err(
+                "--llvm: top-level expression evaluates to a function value".to_string(),
+            );
+        }
     };
 
     let engine: ExecutionEngine = module
@@ -382,10 +405,16 @@ fn compile_program_and_run(
 /// SSA value produced by `emit`. We split int and float because LLVM's
 /// arithmetic / comparison instructions are typed and the dispatch is
 /// cleaner here than re-classifying via `BasicValueEnum` everywhere.
+///
+/// `FuncRef` is a *symbolic* reference to an LLVM function. Capture-
+/// free lambdas produce a FuncRef that can flow through `let` and
+/// land in a Call's head position. FuncRefs don't have a runtime
+/// representation: returning one from the top-level thunk is an error.
 #[derive(Clone, Copy)]
 enum EmitVal<'ctx> {
     Int(IntValue<'ctx>),
     Float(FloatValue<'ctx>),
+    FuncRef(FunctionValue<'ctx>),
 }
 
 impl<'ctx> EmitVal<'ctx> {
@@ -398,11 +427,15 @@ impl<'ctx> EmitVal<'ctx> {
                 other => Err(format!("unsupported integer width: i{}", other)),
             },
             EmitVal::Float(_) => Ok(ReturnKind::F64),
+            EmitVal::FuncRef(_) => Err(
+                "--llvm: top-level expression evaluates to a function value, \
+                 which has no runtime representation in this JIT"
+                    .to_string(),
+            ),
         }
     }
 
-    /// Friendly name for error messages. Mirrors `ReturnKind::name`
-    /// but avoids the `Result` for the common case.
+    /// Friendly name for error messages.
     fn type_name(&self) -> &'static str {
         match self {
             EmitVal::Int(iv) => match iv.get_type().get_bit_width() {
@@ -412,13 +445,20 @@ impl<'ctx> EmitVal<'ctx> {
                 _ => "int(?)",
             },
             EmitVal::Float(_) => "f64",
+            EmitVal::FuncRef(_) => "fn",
         }
     }
 
-    fn as_basic_value_enum(&self) -> BasicValueEnum<'ctx> {
+    /// Convert to a BasicValueEnum where possible. FuncRefs have no
+    /// such representation, so callers that rely on this must already
+    /// have rejected FuncRefs.
+    fn as_basic_value_enum(&self) -> Result<BasicValueEnum<'ctx>, JitError> {
         match self {
-            EmitVal::Int(iv) => (*iv).into(),
-            EmitVal::Float(fv) => (*fv).into(),
+            EmitVal::Int(iv) => Ok((*iv).into()),
+            EmitVal::Float(fv) => Ok((*fv).into()),
+            EmitVal::FuncRef(_) => Err(
+                "--llvm: function reference cannot appear here as a value".to_string(),
+            ),
         }
     }
 }
@@ -428,6 +468,10 @@ impl<'ctx> EmitVal<'ctx> {
 /// `if` / short-circuit forms can append fresh basic blocks.
 struct ExprCg<'ctx, 'a> {
     context: &'ctx Context,
+    /// The LLVM module we're emitting into. Lambda emission needs it
+    /// to register a new `FunctionValue`; arithmetic / control flow
+    /// don't, but the cost of carrying it everywhere is trivial.
+    module: &'a Module<'ctx>,
     builder: &'a Builder<'ctx>,
     function: FunctionValue<'ctx>,
     /// Lexical environment for `let`-bound names and function
@@ -440,6 +484,9 @@ struct ExprCg<'ctx, 'a> {
     /// currently-being-emitted function before its body is processed,
     /// so recursive calls resolve.
     functions: HashMap<String, FunctionValue<'ctx>>,
+    /// Shared counter for `__lambda_N` name generation. A `Cell` so
+    /// nested emits can bump it without re-borrowing `&mut self`.
+    lambda_counter: &'a Cell<u32>,
 }
 
 impl<'ctx, 'a> ExprCg<'ctx, 'a> {
@@ -471,6 +518,16 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             // Top-level `let` (no body) doesn't make sense for a
             // single-thunk JIT and is rejected here.
             Expr::Let { name, value, body, .. } => self.emit_let(name, value, body.as_deref()),
+
+            // `(fn [params] -> ret body)` — a capture-free anonymous
+            // function. We emit it as a real LLVM function with a
+            // synthetic name (`__lambda_N`) and return a `FuncRef`
+            // that can flow through `let` and land at a call site.
+            // The body is emitted with an env containing only the
+            // lambda's params (no enclosing-scope captures).
+            Expr::Lambda { params, return_type, body } => {
+                self.emit_lambda(params, return_type.as_ref(), body)
+            }
 
             // `if` is its own AST node (not a List with "if" symbol).
             Expr::If { condition, then_branch, else_branch } => {
@@ -722,9 +779,14 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             .map_err(|e| format!("LLVM build_unconditional_branch failed: {}", e))?;
 
         // Both arms must produce the same kind. The type checker enforces
-        // this; check defensively.
-        let then_be = then_v.as_basic_value_enum();
-        let else_be = else_v.as_basic_value_enum();
+        // this; check defensively. FuncRef can't go through phi (no
+        // basic-value representation), so we reject it here.
+        let then_be = then_v
+            .as_basic_value_enum()
+            .map_err(|e| format!("`if` then-branch: {}", e))?;
+        let else_be = else_v
+            .as_basic_value_enum()
+            .map_err(|e| format!("`if` else-branch: {}", e))?;
         if then_be.get_type() != else_be.get_type() {
             return Err(format!(
                 "`if` branches have different types ({} vs {}) — \
@@ -746,6 +808,13 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
         Ok(match (then_v, else_v) {
             (EmitVal::Int(_), _) => EmitVal::Int(merged.into_int_value()),
             (EmitVal::Float(_), _) => EmitVal::Float(merged.into_float_value()),
+            (EmitVal::FuncRef(_), _) => {
+                // Unreachable: `as_basic_value_enum` above would have
+                // erred on FuncRef.
+                return Err(
+                    "--llvm: `if` branches cannot produce function values".to_string(),
+                );
+            }
         })
     }
 
@@ -754,9 +823,17 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
     /// Since the parser produces all calls through `Expr::List`, we
     /// take the name as a `&str` directly.
     fn emit_user_call(&mut self, name: &str, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
-        let callee = self.functions.get(name).copied().ok_or_else(|| {
-            format!("--llvm: undefined function `{}`", name)
-        })?;
+        // Resolve the callee. We look first at user `defn`s, then at
+        // the lexical env for `let`-bound `FuncRef`s (capture-free
+        // lambdas land here). User names are kept distinct from
+        // builtin operators by the dispatch in `emit`.
+        let callee = if let Some(fv) = self.functions.get(name).copied() {
+            fv
+        } else if let Some(EmitVal::FuncRef(fv)) = self.env.get(name).copied() {
+            fv
+        } else {
+            return Err(format!("--llvm: undefined function `{}`", name));
+        };
 
         let expected_arity = callee.count_params() as usize;
         if args.len() != expected_arity {
@@ -774,6 +851,12 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             arg_vals.push(match v {
                 EmitVal::Int(iv) => iv.into(),
                 EmitVal::Float(fv) => fv.into(),
+                EmitVal::FuncRef(_) => {
+                    return Err(format!(
+                        "--llvm: cannot pass a function value as an argument to `{}`",
+                        name
+                    ));
+                }
             });
         }
 
@@ -816,6 +899,110 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             }
         }
         result
+    }
+
+    /// `(fn [params] -> ret body)` — emit an anonymous LLVM function
+    /// and return a `FuncRef` to it. The lambda is emitted as a
+    /// top-level module function with a synthetic name (`__lambda_N`).
+    /// It is **capture-free**: the body cannot see any enclosing
+    /// `let`-bound names — that would require closure conversion,
+    /// which is out of scope for the MVP. This is enforced implicitly
+    /// because we build a fresh env containing only the params.
+    ///
+    /// The lambda's body is emitted *before* we return to the
+    /// enclosing emit, but we save and restore the builder position
+    /// so the enclosing function's IR is untouched.
+    fn emit_lambda(
+        &mut self,
+        params: &[(String, Type)],
+        return_type: Option<&Type>,
+        body: &Expr,
+    ) -> Result<EmitVal<'ctx>, JitError> {
+        let ret_ty = return_type.ok_or_else(|| {
+            "--llvm: lambda needs an explicit return type annotation \
+             (e.g. `(fn [x: i32] -> i32 ...)`); inference for lambda \
+             return types is not supported in the MVP"
+                .to_string()
+        })?;
+
+        // Build the LLVM function signature.
+        let param_tys: Vec<BasicMetadataTypeEnum> = params
+            .iter()
+            .map(|(_, ty)| -> Result<BasicMetadataTypeEnum, JitError> {
+                Ok(type_to_basic(self.context, ty)?.into())
+            })
+            .collect::<Result<_, _>>()?;
+        let ret_basic = type_to_basic(self.context, ret_ty)?;
+        let fn_t = ret_basic.fn_type(&param_tys, false);
+
+        // Generate a fresh name. Module-unique by counter.
+        let id = self.lambda_counter.get();
+        self.lambda_counter.set(id + 1);
+        let lambda_name = format!("__lambda_{}", id);
+        let lambda_fv = self.module.add_function(&lambda_name, fn_t, None);
+
+        // Save builder position so we can restore after emitting body.
+        let saved_block = self.builder.get_insert_block();
+
+        // Emit body in a fresh env with only the lambda's params.
+        let entry = self.context.append_basic_block(lambda_fv, "entry");
+        self.builder.position_at_end(entry);
+
+        let mut lambda_env: HashMap<String, EmitVal<'ctx>> = HashMap::new();
+        for (i, (pname, _)) in params.iter().enumerate() {
+            let pv = lambda_fv
+                .get_nth_param(i as u32)
+                .ok_or_else(|| format!("lambda `{}`: missing param {}", lambda_name, i))?;
+            lambda_env.insert(pname.clone(), basic_to_emit(pv)?);
+        }
+
+        let mut inner = ExprCg {
+            context: self.context,
+            module: self.module,
+            builder: self.builder,
+            function: lambda_fv,
+            env: lambda_env,
+            functions: self.functions.clone(),
+            lambda_counter: self.lambda_counter,
+        };
+        let body_val = inner.emit(body)?;
+
+        let body_basic = body_val.as_basic_value_enum().map_err(|e| {
+            format!("lambda `{}`: {}", lambda_name, e)
+        })?;
+        if body_basic.get_type() != ret_basic {
+            return Err(format!(
+                "lambda `{}`: body type {} doesn't match declared return type",
+                lambda_name,
+                body_val.type_name()
+            ));
+        }
+        match body_val {
+            EmitVal::Int(iv) => self
+                .builder
+                .build_return(Some(&iv as &dyn BasicValue))
+                .map(|_| ())
+                .map_err(|e| format!("LLVM build_return failed: {}", e))?,
+            EmitVal::Float(fv) => self
+                .builder
+                .build_return(Some(&fv as &dyn BasicValue))
+                .map(|_| ())
+                .map_err(|e| format!("LLVM build_return failed: {}", e))?,
+            EmitVal::FuncRef(_) => {
+                return Err(format!(
+                    "lambda `{}`: cannot return a function value",
+                    lambda_name
+                ));
+            }
+        };
+
+        // Restore builder position so the enclosing emitter continues
+        // appending to the right block.
+        if let Some(bb) = saved_block {
+            self.builder.position_at_end(bb);
+        }
+
+        Ok(EmitVal::FuncRef(lambda_fv))
     }
 
     /// Short-circuit `and`. Variadic: `(and a b c)` is left-folded so

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -1,0 +1,149 @@
+//! Minimal JIT entry point for Step 2: parse → type-check → codegen → run.
+//!
+//! Only i32 literals and i32 arithmetic (`+`, `-`, `*`, `/`) are supported
+//! at this stage. Each call creates its own LLVM `Context` and module,
+//! wraps the input expression in an anonymous `__expr() -> i32` function,
+//! adds the module to a fresh execution engine, and looks up + calls the
+//! function. This keeps lifetimes simple and tests well isolated.
+
+use inkwell::OptimizationLevel;
+use inkwell::builder::Builder;
+use inkwell::context::Context;
+use inkwell::execution_engine::ExecutionEngine;
+use inkwell::values::IntValue;
+
+use crate::ast::Expr;
+
+pub type JitError = String;
+
+/// Compile and JIT-run `expr` as an `i32`-returning thunk.
+///
+/// `expr` must already have type `i32`; the caller is expected to have
+/// run the type checker. Any unsupported AST node returns an error rather
+/// than panicking, so callers can surface a clean message in the REPL.
+pub fn jit_eval_i32(expr: &Expr) -> Result<i32, JitError> {
+    let context = Context::create();
+    let module = context.create_module("rusp_jit");
+    let builder = context.create_builder();
+
+    // (1) Define `__expr() -> i32`.
+    let i32_t = context.i32_type();
+    let fn_t = i32_t.fn_type(&[], false);
+    let function = module.add_function("__expr", fn_t, None);
+    let entry = context.append_basic_block(function, "entry");
+    builder.position_at_end(entry);
+
+    // (2) Translate the user expression into a single i32 SSA value.
+    let cg = ExprCg {
+        context: &context,
+        builder: &builder,
+    };
+    let value = cg.emit(expr)?;
+    builder
+        .build_return(Some(&value))
+        .map_err(|e| format!("LLVM build_return failed: {}", e))?;
+
+    // (3) JIT and run.
+    let engine: ExecutionEngine =
+        module
+            .create_jit_execution_engine(OptimizationLevel::None)
+            .map_err(|e| format!("failed to create JIT execution engine: {}", e))?;
+
+    // SAFETY: signature `() -> i32` matches what we just emitted, the
+    // module is owned by `engine`, and we drop both before returning.
+    let result = unsafe {
+        let func = engine
+            .get_function::<unsafe extern "C" fn() -> i32>("__expr")
+            .map_err(|e| format!("failed to look up __expr: {}", e))?;
+        func.call()
+    };
+    Ok(result)
+}
+
+/// Per-invocation codegen helper. Borrows the Context/Module/Builder so
+/// that 'ctx flows through cleanly.
+struct ExprCg<'ctx, 'a> {
+    context: &'ctx Context,
+    builder: &'a Builder<'ctx>,
+}
+
+impl<'ctx, 'a> ExprCg<'ctx, 'a> {
+    /// Generate IR for `expr`, returning the resulting i32 SSA value.
+    fn emit(&self, expr: &Expr) -> Result<IntValue<'ctx>, JitError> {
+        match expr {
+            Expr::Integer32(n) => {
+                // i32 literal — sign-extending the i64 cast is fine for
+                // negative values because const_int treats the source as a
+                // sign-extended u64.
+                Ok(self.context.i32_type().const_int(*n as u64, true))
+            }
+
+            // Operator forms `(op a b ...)` parse as `Expr::List` with the
+            // operator symbol at position 0. We dispatch on the symbol and
+            // hand off to `gen_arith`.
+            Expr::List(exprs) if !exprs.is_empty() => {
+                if let Expr::Symbol(op) = &exprs[0] {
+                    match op.as_str() {
+                        "+" | "-" | "*" | "/" => self.gen_arith(op, &exprs[1..]),
+                        other => Err(format!(
+                            "--llvm: operator `{}` not supported yet",
+                            other
+                        )),
+                    }
+                } else {
+                    Err("--llvm: only operator-headed lists are supported in Step 2".to_string())
+                }
+            }
+
+            // `Expr::Call` is what bare `(f x y)` parses to. For Step 2
+            // we only handle the operator forms above, which always come
+            // through `Expr::List`. Calls land here only for user-defined
+            // functions, which Step 7 will enable.
+            Expr::Call { .. } => {
+                Err("--llvm: function calls are not supported yet (Step 7)".to_string())
+            }
+
+            other => Err(format!(
+                "--llvm: AST node {:?} is not supported by the MVP yet",
+                std::mem::discriminant(other)
+            )),
+        }
+    }
+
+    /// Generate `(op arg0 arg1 ...)` for binary i32 arithmetic. Variadic
+    /// in source (`(+ 1 2 3)`) is left-folded.
+    fn gen_arith(&self, op: &str, args: &[Expr]) -> Result<IntValue<'ctx>, JitError> {
+        if args.len() < 2 {
+            return Err(format!(
+                "operator `{}` requires at least 2 arguments, got {}",
+                op,
+                args.len()
+            ));
+        }
+
+        let mut acc = self.emit(&args[0])?;
+        for arg in &args[1..] {
+            let rhs = self.emit(arg)?;
+            acc = match op {
+                "+" => self
+                    .builder
+                    .build_int_add(acc, rhs, "addtmp")
+                    .map_err(|e| format!("LLVM build_int_add failed: {}", e))?,
+                "-" => self
+                    .builder
+                    .build_int_sub(acc, rhs, "subtmp")
+                    .map_err(|e| format!("LLVM build_int_sub failed: {}", e))?,
+                "*" => self
+                    .builder
+                    .build_int_mul(acc, rhs, "multmp")
+                    .map_err(|e| format!("LLVM build_int_mul failed: {}", e))?,
+                "/" => self
+                    .builder
+                    .build_int_signed_div(acc, rhs, "divtmp")
+                    .map_err(|e| format!("LLVM build_int_signed_div failed: {}", e))?,
+                _ => unreachable!("operator dispatch checked already"),
+            };
+        }
+        Ok(acc)
+    }
+}

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -1,4 +1,4 @@
-//! Minimal JIT entry point for Steps 2–6: parse → type-check → codegen → run.
+//! Minimal JIT entry point for Steps 2–7: parse → type-check → codegen → run.
 //!
 //! Supports:
 //! - i32/i64 literals and integer arithmetic (`+`, `-`, `*`, `/`)
@@ -8,6 +8,7 @@
 //! - `if` (with phi-merge)
 //! - `and`/`or`/`not` (short-circuit for `and`/`or`, xor for `not`)
 //! - `let`-in (lexical bindings via a flat HashMap; SSA values, no alloca)
+//! - `defn` + `(f x y)` calls, including direct recursion
 //!
 //! Integer arithmetic / comparison forms infer their width from the
 //! leading operand; the type checker has already enforced that every
@@ -22,13 +23,16 @@ use inkwell::OptimizationLevel;
 use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::execution_engine::ExecutionEngine;
-use inkwell::types::{BasicType, BasicTypeEnum};
-use inkwell::values::{BasicValue, BasicValueEnum, FloatValue, FunctionValue, IntValue};
+use inkwell::module::Module;
+use inkwell::types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum};
+use inkwell::values::{
+    BasicMetadataValueEnum, BasicValue, BasicValueEnum, FloatValue, FunctionValue, IntValue,
+};
 use inkwell::{FloatPredicate, IntPredicate};
 
 use std::collections::HashMap;
 
-use crate::ast::Expr;
+use crate::ast::{Expr, Type};
 
 pub type JitError = String;
 
@@ -38,18 +42,12 @@ pub type JitError = String;
 /// run the type checker. Any unsupported AST node returns an error rather
 /// than panicking, so callers can surface a clean message in the REPL.
 pub fn jit_eval_i32(expr: &Expr) -> Result<i32, JitError> {
-    let context = Context::create();
-    let result = compile_and_run(&context, expr, ReturnKind::I32)?;
-    // SAFETY of the cast: the JIT returned an i32 inside a u64 (we trampoline
-    // through u64 to keep one signature for both widths). Truncation is safe.
-    Ok(result.as_u64 as i32)
+    jit_eval_i32_program(std::slice::from_ref(expr))
 }
 
 /// Compile and JIT-run `expr` as an `i64`-returning thunk.
 pub fn jit_eval_i64(expr: &Expr) -> Result<i64, JitError> {
-    let context = Context::create();
-    let result = compile_and_run(&context, expr, ReturnKind::I64)?;
-    Ok(result.as_u64 as i64)
+    jit_eval_i64_program(std::slice::from_ref(expr))
 }
 
 /// Compile and JIT-run `expr` as a `bool`-returning thunk.
@@ -59,18 +57,185 @@ pub fn jit_eval_i64(expr: &Expr) -> Result<i64, JitError> {
 /// comparing against zero is portable and is what every other inkwell
 /// example does too.
 pub fn jit_eval_bool(expr: &Expr) -> Result<bool, JitError> {
-    let context = Context::create();
-    let result = compile_and_run(&context, expr, ReturnKind::Bool)?;
-    Ok(result.as_u64 != 0)
+    jit_eval_bool_program(std::slice::from_ref(expr))
 }
 
 /// Compile and JIT-run `expr` as an `f64`-returning thunk. Floats can't
 /// trampoline through u64 (different ABI registers, no bitcast at the
 /// boundary), so the float case is handled separately.
 pub fn jit_eval_f64(expr: &Expr) -> Result<f64, JitError> {
+    jit_eval_f64_program(std::slice::from_ref(expr))
+}
+
+/// Program-form variants: any number of leading `defn` forms followed
+/// by a final expression. The defns are emitted as real LLVM functions
+/// (so they're available for `Call` and recursion); the final expression
+/// becomes the body of the `__expr` thunk. Empty slices and slices that
+/// don't end in an expression-shaped form are rejected.
+pub fn jit_eval_i32_program(forms: &[Expr]) -> Result<i32, JitError> {
     let context = Context::create();
-    let result = compile_and_run(&context, expr, ReturnKind::F64)?;
+    let result = compile_program_and_run(&context, forms, ReturnKind::I32)?;
+    Ok(result.as_u64 as i32)
+}
+
+pub fn jit_eval_i64_program(forms: &[Expr]) -> Result<i64, JitError> {
+    let context = Context::create();
+    let result = compile_program_and_run(&context, forms, ReturnKind::I64)?;
+    Ok(result.as_u64 as i64)
+}
+
+pub fn jit_eval_bool_program(forms: &[Expr]) -> Result<bool, JitError> {
+    let context = Context::create();
+    let result = compile_program_and_run(&context, forms, ReturnKind::Bool)?;
+    Ok(result.as_u64 != 0)
+}
+
+pub fn jit_eval_f64_program(forms: &[Expr]) -> Result<f64, JitError> {
+    let context = Context::create();
+    let result = compile_program_and_run(&context, forms, ReturnKind::F64)?;
     Ok(result.as_f64)
+}
+
+/// Split a program slice into `(leading defns, final expression)`.
+/// Returns an error if the slice is empty or doesn't end in something
+/// that can be the result expression. We don't enforce that all defns
+/// must precede the expression — a `defn` after the result expression
+/// would be unreachable in this single-thunk model.
+fn split_program(forms: &[Expr]) -> Result<(Vec<&Expr>, &Expr), JitError> {
+    if forms.is_empty() {
+        return Err("--llvm: empty program (need at least one expression)".to_string());
+    }
+    let last_idx = forms.len() - 1;
+    let last = &forms[last_idx];
+    if matches!(last, Expr::Defn { .. }) {
+        return Err(
+            "--llvm: program's last form must be an expression, not a `defn`".to_string(),
+        );
+    }
+    let mut defns: Vec<&Expr> = Vec::with_capacity(last_idx);
+    for f in &forms[..last_idx] {
+        if !matches!(f, Expr::Defn { .. }) {
+            return Err(
+                "--llvm: only leading `defn` forms followed by one expression are supported"
+                    .to_string(),
+            );
+        }
+        defns.push(f);
+    }
+    Ok((defns, last))
+}
+
+/// Emit a `defn` as a real LLVM function in `module`. Registers the
+/// function value in `functions` *before* emitting the body so
+/// recursive calls resolve. Parameters become entries in the body's
+/// `env`. The body must produce a value matching the declared return
+/// type.
+fn emit_defn<'ctx>(
+    context: &'ctx Context,
+    module: &Module<'ctx>,
+    builder: &Builder<'ctx>,
+    functions: &mut HashMap<String, FunctionValue<'ctx>>,
+    expr: &Expr,
+) -> Result<(), JitError> {
+    let Expr::Defn { name, params, return_type, body } = expr else {
+        return Err("emit_defn called with non-Defn".to_string());
+    };
+
+    let param_tys: Vec<BasicMetadataTypeEnum> = params
+        .iter()
+        .map(|(_, ty)| -> Result<BasicMetadataTypeEnum, JitError> {
+            Ok(type_to_basic(context, ty)?.into())
+        })
+        .collect::<Result<_, _>>()?;
+    let ret_basic = type_to_basic(context, return_type)?;
+    let fn_t = ret_basic.fn_type(&param_tys, false);
+    let function = module.add_function(name, fn_t, None);
+    functions.insert(name.clone(), function);
+
+    let entry = context.append_basic_block(function, "entry");
+    builder.position_at_end(entry);
+
+    // Bind params into the env.
+    let mut env: HashMap<String, EmitVal<'ctx>> = HashMap::new();
+    for (i, (pname, _)) in params.iter().enumerate() {
+        let pv = function
+            .get_nth_param(i as u32)
+            .ok_or_else(|| format!("defn `{}`: missing param {}", name, i))?;
+        env.insert(pname.clone(), basic_to_emit(pv)?);
+    }
+
+    let mut cg = ExprCg {
+        context,
+        builder,
+        function,
+        env,
+        functions: functions.clone(),
+    };
+    let body_val = cg.emit(body)?;
+
+    // Body's kind must agree with the declared return type.
+    let body_basic = body_val.as_basic_value_enum();
+    if body_basic.get_type() != ret_basic {
+        return Err(format!(
+            "defn `{}`: body type {} doesn't match declared return type",
+            name,
+            body_val.type_name()
+        ));
+    }
+
+    match body_val {
+        EmitVal::Int(iv) => builder
+            .build_return(Some(&iv as &dyn BasicValue))
+            .map(|_| ())
+            .map_err(|e| format!("LLVM build_return failed: {}", e))?,
+        EmitVal::Float(fv) => builder
+            .build_return(Some(&fv as &dyn BasicValue))
+            .map(|_| ())
+            .map_err(|e| format!("LLVM build_return failed: {}", e))?,
+    };
+
+    // Functions discovered while emitting this body (none for now,
+    // since defns aren't nested) flow back via the cg.functions
+    // copy. Merge new entries.
+    for (k, v) in cg.functions {
+        functions.entry(k).or_insert(v);
+    }
+    Ok(())
+}
+
+/// Map a Rusp `Type` to the LLVM basic type used for a function
+/// parameter or return slot. Only scalar Rusp types are supported.
+fn type_to_basic<'ctx>(context: &'ctx Context, ty: &Type) -> Result<BasicTypeEnum<'ctx>, JitError> {
+    Ok(match ty {
+        Type::I32 => context.i32_type().into(),
+        Type::I64 => context.i64_type().into(),
+        Type::Bool => context.bool_type().into(),
+        Type::F64 => context.f64_type().into(),
+        Type::String => return Err("--llvm: String type is not supported by the MVP".to_string()),
+        Type::List(_) => return Err("--llvm: List type is not supported by the MVP".to_string()),
+        Type::Function { .. } => {
+            return Err("--llvm: first-class function types are not supported by the MVP".to_string());
+        }
+        Type::Inferred => {
+            return Err(
+                "--llvm: inferred type leaked to codegen — type checker should have resolved it"
+                    .to_string(),
+            );
+        }
+    })
+}
+
+/// Wrap a function param's `BasicValueEnum` as an `EmitVal`. Floats
+/// become Float, all integer widths become Int.
+fn basic_to_emit(v: BasicValueEnum<'_>) -> Result<EmitVal<'_>, JitError> {
+    match v {
+        BasicValueEnum::IntValue(iv) => Ok(EmitVal::Int(iv)),
+        BasicValueEnum::FloatValue(fv) => Ok(EmitVal::Float(fv)),
+        other => Err(format!(
+            "--llvm: function param has unsupported LLVM type {:?}",
+            other.get_type()
+        )),
+    }
 }
 
 /// What the top-level thunk should return. Determines the function
@@ -113,16 +278,27 @@ impl BoundaryValue {
     }
 }
 
-/// Compile, JIT, and run `__expr` returning a single scalar of the
-/// requested kind.
-fn compile_and_run(
+/// Compile, JIT, and run a program: zero or more leading `defn` forms
+/// followed by exactly one expression that becomes `__expr`'s body.
+fn compile_program_and_run(
     context: &Context,
-    expr: &Expr,
+    forms: &[Expr],
     expected: ReturnKind,
 ) -> Result<BoundaryValue, JitError> {
+    let (defns, expr) = split_program(forms)?;
+
     let module = context.create_module("rusp_jit");
     let builder = context.create_builder();
 
+    // Emit each `defn` as a real LLVM function. The function is
+    // registered in `functions` *before* its body is emitted so that
+    // recursive self-calls resolve.
+    let mut functions: HashMap<String, FunctionValue<'_>> = HashMap::new();
+    for d in &defns {
+        emit_defn(context, &module, &builder, &mut functions, d)?;
+    }
+
+    // Now emit the top-level thunk for the final expression.
     let ret_t: BasicTypeEnum = match expected {
         ReturnKind::I32 => context.i32_type().into(),
         ReturnKind::I64 => context.i64_type().into(),
@@ -139,6 +315,7 @@ fn compile_and_run(
         builder: &builder,
         function,
         env: HashMap::new(),
+        functions,
     };
     let value = cg.emit(expr)?;
 
@@ -253,11 +430,16 @@ struct ExprCg<'ctx, 'a> {
     context: &'ctx Context,
     builder: &'a Builder<'ctx>,
     function: FunctionValue<'ctx>,
-    /// Lexical environment for `let`-bound names. Flat (no parent
-    /// chain) because rebinding via shadowing is implemented by
-    /// snapshotting the displaced entry and restoring it after the
-    /// body. SSA-style: each binding maps to a value, not an alloca.
+    /// Lexical environment for `let`-bound names and function
+    /// parameters. Flat (no parent chain): rebinding via shadowing is
+    /// implemented by snapshotting the displaced entry and restoring
+    /// it after the body. SSA-style — each binding maps to a value,
+    /// not an alloca.
     env: HashMap<String, EmitVal<'ctx>>,
+    /// User-defined functions (from `defn`) by name. Includes the
+    /// currently-being-emitted function before its body is processed,
+    /// so recursive calls resolve.
+    functions: HashMap<String, FunctionValue<'ctx>>,
 }
 
 impl<'ctx, 'a> ExprCg<'ctx, 'a> {
@@ -295,8 +477,12 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
                 self.emit_if(condition, then_branch, else_branch)
             }
 
-            // Operator forms `(op a b ...)` parse as `Expr::List` with the
-            // operator symbol at position 0. Dispatch on the symbol.
+            // S-expression forms `(head a b ...)` parse as `Expr::List`.
+            // The head determines what to do: built-in operators get
+            // dedicated codegen; anything else is treated as a user-
+            // defined function call resolved via `self.functions`.
+            // (The parser doesn't produce `Expr::Call`; that variant
+            // exists in the AST but isn't emitted from S-expressions.)
             Expr::List(exprs) if !exprs.is_empty() => {
                 if let Expr::Symbol(op) = &exprs[0] {
                     let args = &exprs[1..];
@@ -307,19 +493,20 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
                         "and" => self.gen_and(args),
                         "or" => self.gen_or(args),
                         "not" => self.gen_not(args),
-                        other => Err(format!(
-                            "--llvm: operator `{}` not supported yet",
-                            other
-                        )),
+                        // Fall through to user-function call.
+                        _ => self.emit_user_call(op, args),
                     }
                 } else {
-                    Err("--llvm: only operator-headed lists are supported in Step 5".to_string())
+                    Err("--llvm: only symbol-headed lists are supported".to_string())
                 }
             }
 
-            Expr::Call { .. } => {
-                Err("--llvm: function calls are not supported yet (Step 7)".to_string())
-            }
+            // `Expr::Call` is in the AST but the current parser never
+            // produces it; if it ever does, route through emit_user_call.
+            Expr::Call { func, args } => match func.as_ref() {
+                Expr::Symbol(name) => self.emit_user_call(name, args),
+                _ => Err("--llvm: only direct function calls are supported".to_string()),
+            },
 
             other => Err(format!(
                 "--llvm: AST node {:?} is not supported by the MVP yet",
@@ -560,6 +747,45 @@ impl<'ctx, 'a> ExprCg<'ctx, 'a> {
             (EmitVal::Int(_), _) => EmitVal::Int(merged.into_int_value()),
             (EmitVal::Float(_), _) => EmitVal::Float(merged.into_float_value()),
         })
+    }
+
+    /// `(name arg1 arg2 ...)` — call a user-defined function. The
+    /// callee must resolve to a name registered in `self.functions`.
+    /// Since the parser produces all calls through `Expr::List`, we
+    /// take the name as a `&str` directly.
+    fn emit_user_call(&mut self, name: &str, args: &[Expr]) -> Result<EmitVal<'ctx>, JitError> {
+        let callee = self.functions.get(name).copied().ok_or_else(|| {
+            format!("--llvm: undefined function `{}`", name)
+        })?;
+
+        let expected_arity = callee.count_params() as usize;
+        if args.len() != expected_arity {
+            return Err(format!(
+                "--llvm: `{}` expects {} arguments, got {}",
+                name,
+                expected_arity,
+                args.len()
+            ));
+        }
+
+        let mut arg_vals: Vec<BasicMetadataValueEnum<'ctx>> = Vec::with_capacity(args.len());
+        for a in args {
+            let v = self.emit(a)?;
+            arg_vals.push(match v {
+                EmitVal::Int(iv) => iv.into(),
+                EmitVal::Float(fv) => fv.into(),
+            });
+        }
+
+        let call_site = self
+            .builder
+            .build_call(callee, &arg_vals, "calltmp")
+            .map_err(|e| format!("LLVM build_call failed: {}", e))?;
+        let ret = call_site
+            .try_as_basic_value()
+            .basic()
+            .ok_or_else(|| format!("--llvm: `{}` returns void; can't use as a value", name))?;
+        basic_to_emit(ret)
     }
 
     /// `(let name value body)` — let-in. Bind `name` to the value of

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -18,4 +18,7 @@ pub fn smoke_module() -> String {
     module.print_to_string().to_string()
 }
 
-pub use jit::{jit_eval_bool, jit_eval_f64, jit_eval_i32, jit_eval_i64, JitError};
+pub use jit::{
+    jit_eval_bool, jit_eval_bool_program, jit_eval_f64, jit_eval_f64_program, jit_eval_i32,
+    jit_eval_i32_program, jit_eval_i64, jit_eval_i64_program, JitError,
+};

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -18,4 +18,4 @@ pub fn smoke_module() -> String {
     module.print_to_string().to_string()
 }
 
-pub use jit::{jit_eval_bool, jit_eval_i32, jit_eval_i64, JitError};
+pub use jit::{jit_eval_bool, jit_eval_f64, jit_eval_i32, jit_eval_i64, JitError};

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,0 +1,21 @@
+//! LLVM codegen backend (MVP).
+//!
+//! Submodules are filled in incrementally. The current scope (Step 2)
+//! supports i32 literals and i32 arithmetic via JIT.
+
+pub mod jit;
+
+use inkwell::context::Context;
+
+/// Build an empty LLVM module and return its textual IR.
+///
+/// Used in Step 1 as a smoke test that LLVM linkage is set up correctly.
+/// Kept around because `cargo test smoke_module` is a fast diagnostic
+/// when LLVM linking starts misbehaving.
+pub fn smoke_module() -> String {
+    let context = Context::create();
+    let module = context.create_module("rusp_smoke");
+    module.print_to_string().to_string()
+}
+
+pub use jit::{jit_eval_i32, JitError};

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3,6 +3,7 @@
 //! Submodules are filled in incrementally. The current scope (Step 2)
 //! supports i32 literals and i32 arithmetic via JIT.
 
+pub mod aot;
 pub mod jit;
 
 use inkwell::context::Context;
@@ -18,6 +19,7 @@ pub fn smoke_module() -> String {
     module.print_to_string().to_string()
 }
 
+pub use aot::{compile_to_ll, compile_to_obj};
 pub use jit::{
     jit_eval_bool, jit_eval_bool_program, jit_eval_f64, jit_eval_f64_program, jit_eval_i32,
     jit_eval_i32_program, jit_eval_i64, jit_eval_i64_program, JitError,

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -18,4 +18,4 @@ pub fn smoke_module() -> String {
     module.print_to_string().to_string()
 }
 
-pub use jit::{jit_eval_i32, JitError};
+pub use jit::{jit_eval_i32, jit_eval_i64, JitError};

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -18,4 +18,4 @@ pub fn smoke_module() -> String {
     module.print_to_string().to_string()
 }
 
-pub use jit::{jit_eval_i32, jit_eval_i64, JitError};
+pub use jit::{jit_eval_bool, jit_eval_i32, jit_eval_i64, JitError};

--- a/src/env.rs
+++ b/src/env.rs
@@ -73,6 +73,12 @@ pub struct Environment {
     parent: Option<Box<Environment>>,
 }
 
+impl Default for Environment {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Environment {
     pub fn new() -> Self {
         let mut env = Environment {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,15 @@
+//! Rusp library crate.
+//!
+//! Exposing parser/types/eval lets the LLVM codegen module — and tests for
+//! it — share the same front end as the binary REPL.
+
+pub mod ast;
+pub mod codegen;
+pub mod env;
+pub mod eval;
+pub mod exhaustiveness;
+pub mod parser;
+pub mod types;
+
+#[cfg(test)]
+mod tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,37 @@
 use std::io::{self, Write};
 
-use rusp::ast;
+use rusp::ast::{self, Expr, Type};
+use rusp::codegen;
 use rusp::env::{self, Environment};
 use rusp::eval::eval;
 use rusp::parser;
 use rusp::types::{type_check, TypeEnv};
 
 fn main() {
-    println!("Rusp REPL v0.1.0");
+    // CLI: `--llvm` switches the evaluation backend from the tree-walking
+    // interpreter to the LLVM JIT. Type checking still runs on every form
+    // so the user gets the same diagnostics either way.
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let use_llvm = args.iter().any(|a| a == "--llvm");
+    let unknown: Vec<&String> = args.iter().filter(|a| a.as_str() != "--llvm").collect();
+    if !unknown.is_empty() {
+        eprintln!("Rusp: unknown argument(s): {:?}", unknown);
+        eprintln!("Usage: rusp [--llvm]");
+        std::process::exit(2);
+    }
+
+    println!("Rusp REPL v0.1.0{}", if use_llvm { " (LLVM JIT mode)" } else { "" });
     println!("Type 'exit' or press Ctrl+C to quit");
     println!("(blank line cancels a multi-line input)\n");
 
     let mut env = Environment::new();
     let mut type_env = TypeEnv::new();
+    // In `--llvm` mode each expression is compiled in a fresh module, so
+    // any `defn`s the user has typed earlier need to be re-emitted along
+    // with the new expression. We keep the AST around and prepend it.
+    // Tree-walking mode doesn't need this because `Environment` retains
+    // bindings across calls.
+    let mut jit_defns: Vec<Expr> = Vec::new();
 
     // Accumulates partial input across lines when brackets are not yet
     // balanced. Empty once the user has dispatched a complete form.
@@ -60,12 +79,20 @@ fn main() {
                 let input = std::mem::take(&mut buffer);
                 let input = input.trim();
 
-                match process_input(input, &mut env, &mut type_env) {
-                    Ok((value, ty)) => {
-                        println!("{}: {}", value, ty);
+                if use_llvm {
+                    match process_input_llvm(input, &mut type_env, &mut jit_defns) {
+                        Ok(Some((rendered, ty))) => println!("{}: {}", rendered, ty),
+                        Ok(None) => {} // form was a defn — silently accumulated
+                        Err(e) => eprintln!("Error: {}", e),
                     }
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
+                } else {
+                    match process_input(input, &mut env, &mut type_env) {
+                        Ok((value, ty)) => {
+                            println!("{}: {}", value, ty);
+                        }
+                        Err(e) => {
+                            eprintln!("Error: {}", e);
+                        }
                     }
                 }
             }
@@ -124,6 +151,52 @@ fn process_input(
     let value = eval(&ast, env)?;
 
     Ok((value, ty))
+}
+
+/// `--llvm` REPL pipeline.
+///
+/// Always runs parse + type-check (so the user gets a uniform diagnostic
+/// experience regardless of backend). For `defn`, the form is registered
+/// in the type env and accumulated in `jit_defns` so subsequent
+/// expressions can call it; we don't JIT anything in this case and
+/// return `Ok(None)`.
+///
+/// For an expression, we build a program slice of `[..jit_defns, expr]`
+/// and dispatch to the right `jit_eval_*_program` based on the
+/// expression's type. The result is rendered as a string for printing.
+///
+/// Top-level `let` (without body), `match`, list literals, and string
+/// literals fall outside the MVP JIT scope and produce a clean error.
+fn process_input_llvm(
+    input: &str,
+    type_env: &mut TypeEnv,
+    jit_defns: &mut Vec<Expr>,
+) -> Result<Option<(String, Type)>, String> {
+    let ast = parser::parse(input).map_err(|e| e.to_string())?;
+    let ty = type_check(&ast, type_env)?;
+
+    if matches!(ast, Expr::Defn { .. }) {
+        // Type-checked successfully → register for future calls.
+        jit_defns.push(ast);
+        return Ok(None);
+    }
+
+    let mut program: Vec<Expr> = jit_defns.clone();
+    program.push(ast);
+
+    let rendered = match &ty {
+        Type::I32 => codegen::jit_eval_i32_program(&program)?.to_string(),
+        Type::I64 => codegen::jit_eval_i64_program(&program)?.to_string(),
+        Type::Bool => codegen::jit_eval_bool_program(&program)?.to_string(),
+        Type::F64 => codegen::jit_eval_f64_program(&program)?.to_string(),
+        other => {
+            return Err(format!(
+                "--llvm: result type {} is not supported by the JIT MVP",
+                other
+            ));
+        }
+    };
+    Ok(Some((rendered, ty)))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,15 +8,27 @@ use rusp::parser;
 use rusp::types::{type_check, TypeEnv};
 
 fn main() {
-    // CLI: `--llvm` switches the evaluation backend from the tree-walking
-    // interpreter to the LLVM JIT. Type checking still runs on every form
-    // so the user gets the same diagnostics either way.
+    // CLI dispatch:
+    //   rusp                       → REPL (tree-walking interpreter)
+    //   rusp --llvm                → REPL (LLVM JIT)
+    //   rusp build FILE --emit ll  → write FILE.ll
+    //   rusp build FILE --emit obj → write FILE.o
     let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Some(first) = args.first()
+        && first == "build"
+    {
+        if let Err(e) = run_build(&args[1..]) {
+            eprintln!("rusp build: {}", e);
+            std::process::exit(1);
+        }
+        return;
+    }
+
     let use_llvm = args.iter().any(|a| a == "--llvm");
     let unknown: Vec<&String> = args.iter().filter(|a| a.as_str() != "--llvm").collect();
     if !unknown.is_empty() {
         eprintln!("Rusp: unknown argument(s): {:?}", unknown);
-        eprintln!("Usage: rusp [--llvm]");
+        eprintln!("Usage: rusp [--llvm] | rusp build FILE --emit ll|obj");
         std::process::exit(2);
     }
 
@@ -151,6 +163,80 @@ fn process_input(
     let value = eval(&ast, env)?;
 
     Ok((value, ty))
+}
+
+/// `rusp build FILE --emit ll|obj` — read source, type-check every
+/// form, and emit either textual LLVM IR or a native object.
+///
+/// The source must be a sequence of `defn`s ending with
+/// `(defn main [] -> i32 ...)`; that defn becomes the C-ABI entry
+/// point, so `cc out.o -o out` is enough to make an executable.
+fn run_build(args: &[String]) -> Result<(), String> {
+    // Parse the sub-arg vector. We expect: <file> --emit <kind>.
+    let mut file: Option<&String> = None;
+    let mut emit: Option<&String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--emit" => {
+                i += 1;
+                emit = args.get(i);
+                if emit.is_none() {
+                    return Err("--emit requires an argument (ll|obj)".into());
+                }
+            }
+            other if !other.starts_with("--") => {
+                if file.is_some() {
+                    return Err(format!("unexpected positional argument: {}", other));
+                }
+                file = Some(&args[i]);
+            }
+            other => return Err(format!("unknown flag: {}", other)),
+        }
+        i += 1;
+    }
+    let file = file.ok_or("missing input file. Usage: rusp build FILE --emit ll|obj")?;
+    let emit = emit.ok_or("missing --emit. Usage: rusp build FILE --emit ll|obj")?;
+
+    let source = std::fs::read_to_string(file)
+        .map_err(|e| format!("could not read {}: {}", file, e))?;
+
+    // Parse all top-level forms. The single-form `parser::parse` rejects
+    // trailing input, so we drive `parse_expr` in a loop.
+    let mut forms: Vec<Expr> = Vec::new();
+    let mut rest = source.trim();
+    while !rest.is_empty() {
+        let (remaining, expr) = parser::expr::parse_expr(rest)
+            .map_err(|e| format!("parse error: {}", e))?;
+        forms.push(expr);
+        rest = remaining.trim();
+    }
+
+    // Type-check every form against a shared TypeEnv so `defn`s can
+    // reference each other.
+    let mut type_env = TypeEnv::new();
+    for f in &forms {
+        rusp::types::type_check(f, &mut type_env)
+            .map_err(|e| format!("type error: {}", e))?;
+    }
+
+    match emit.as_str() {
+        "ll" => {
+            let ir = codegen::compile_to_ll(&forms)?;
+            let out_path = format!("{}.ll", file);
+            std::fs::write(&out_path, ir)
+                .map_err(|e| format!("could not write {}: {}", out_path, e))?;
+            eprintln!("wrote {}", out_path);
+            Ok(())
+        }
+        "obj" => {
+            let out_path = format!("{}.o", file);
+            codegen::compile_to_obj(&forms, std::path::Path::new(&out_path))?;
+            eprintln!("wrote {}", out_path);
+            Ok(())
+        }
+        other => Err(format!("--emit: expected `ll` or `obj`, got `{}`", other)),
+    }
 }
 
 /// `--llvm` REPL pipeline.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,10 @@
-mod ast;
-mod env;
-mod eval;
-mod exhaustiveness;
-mod parser;
-mod types;
-
-#[cfg(test)]
-mod tests;
-
 use std::io::{self, Write};
 
-use env::Environment;
-use eval::eval;
-use types::{type_check, TypeEnv};
+use rusp::ast;
+use rusp::env::{self, Environment};
+use rusp::eval::eval;
+use rusp::parser;
+use rusp::types::{type_check, TypeEnv};
 
 fn main() {
     println!("Rusp REPL v0.1.0");

--- a/src/tests/codegen_tests.rs
+++ b/src/tests/codegen_tests.rs
@@ -515,4 +515,73 @@ mod tests {
             err
         );
     }
+
+    // -------- Step 8: capture-free lambdas --------
+
+    #[test]
+    fn jit_lambda_let_bound_and_called_i32() {
+        // `(let f (fn ...) (f 21))` — the lambda flows through let as a
+        // FuncRef and lands at the call site.
+        let src = "(let twice (fn [x: i32] -> i32 (* x 2)) (twice 21))";
+        assert_eq!(jit_i32(src).unwrap(), 42);
+    }
+
+    #[test]
+    fn jit_lambda_two_params() {
+        let src = "(let add (fn [x: i32 y: i32] -> i32 (+ x y)) (add 3 4))";
+        assert_eq!(jit_i32(src).unwrap(), 7);
+    }
+
+    #[test]
+    fn jit_lambda_returning_bool() {
+        let src = "(let is-pos (fn [x: i32] -> bool (> x 0)) (is-pos 5))";
+        let forms = parse_program(src);
+        assert!(codegen::jit_eval_bool_program(&forms).unwrap());
+    }
+
+    #[test]
+    fn jit_lambda_returning_f64() {
+        let src = "(let half (fn [x: f64] -> f64 (*. x 0.5)) (half 8.0))";
+        let forms = parse_program(src);
+        let r = codegen::jit_eval_f64_program(&forms).unwrap();
+        assert!((r - 4.0).abs() < 1e-9, "got {}", r);
+    }
+
+    #[test]
+    fn jit_lambda_inside_defn_body() {
+        // Lambda emitted inside a defn — exercises the `module` /
+        // `lambda_counter` threading through the inner ExprCg.
+        let src = r#"
+            (defn apply-double [n: i32] -> i32
+              (let f (fn [x: i32] -> i32 (* x 2))
+                (f n)))
+            (apply-double 21)
+        "#;
+        assert_eq!(jit_i32_prog(src).unwrap(), 42);
+    }
+
+    #[test]
+    fn jit_lambda_top_level_returns_funcref_error() {
+        // Returning a lambda directly as the program's value — there's
+        // no boundary representation for FuncRef, so we must reject.
+        let err = jit_i32("(fn [x: i32] -> i32 x)").unwrap_err();
+        assert!(
+            err.contains("function value") || err.contains("function reference"),
+            "expected function-value rejection, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn jit_lambda_without_return_type_errors() {
+        // The MVP requires explicit return type on lambdas so codegen
+        // doesn't have to do its own inference.
+        let src = "(let twice (fn [x: i32] (* x 2)) (twice 21))";
+        let err = jit_i32(src).unwrap_err();
+        assert!(
+            err.contains("return type"),
+            "expected return-type error, got: {}",
+            err
+        );
+    }
 }

--- a/src/tests/codegen_tests.rs
+++ b/src/tests/codegen_tests.rs
@@ -290,12 +290,83 @@ mod tests {
         assert!(!err.is_empty());
     }
 
+    // ----------- Step 6: let-in -----------
+
+    #[test]
+    fn jit_let_in_basic_i32() {
+        // (let x 5 x) → 5
+        assert_eq!(jit_i32("(let x 5 x)").unwrap(), 5);
+        // Body uses bound name in arithmetic.
+        assert_eq!(jit_i32("(let x 10 (+ x 1))").unwrap(), 11);
+    }
+
+    #[test]
+    fn jit_let_in_basic_f64() {
+        assert_eq!(jit_f64("(let half 0.5 half)").unwrap(), 0.5);
+        assert_eq!(jit_f64("(let r 2.0 (*. r r))").unwrap(), 4.0);
+    }
+
+    #[test]
+    fn jit_let_in_basic_bool() {
+        assert!(jit_bool("(let p true p)").unwrap());
+        assert!(jit_bool("(let p false (not p))").unwrap());
+    }
+
+    #[test]
+    fn jit_let_in_nested() {
+        // Nested let — outer binding visible inside inner body.
+        assert_eq!(jit_i32("(let x 3 (let y 4 (+ x y)))").unwrap(), 7);
+        // Inner binding shadows outer; body uses inner.
+        assert_eq!(jit_i32("(let x 1 (let x 99 x))").unwrap(), 99);
+    }
+
+    #[test]
+    fn jit_let_in_shadowing_restores() {
+        // After the inner let's body, `x` should refer to the outer binding
+        // again. Achieved by computing `(+ inner outer)` where the outer x
+        // is read after the inner let scope ends.
+        // (let x 10 (+ (let x 1 x) x)) → (+ 1 10) = 11
+        assert_eq!(
+            jit_i32("(let x 10 (+ (let x 1 x) x))").unwrap(),
+            11
+        );
+    }
+
+    #[test]
+    fn jit_let_in_with_if() {
+        // Bound value used in both arms.
+        assert_eq!(
+            jit_i32("(let x 5 (if (< x 10) (* x 2) x))").unwrap(),
+            10
+        );
+    }
+
+    #[test]
+    fn jit_let_in_value_can_use_outer_bindings() {
+        // `value` can reference earlier let-bound names.
+        assert_eq!(
+            jit_i32("(let x 3 (let y (* x 2) y))").unwrap(),
+            6
+        );
+    }
+
+    #[test]
+    fn jit_undefined_variable_is_error() {
+        // No binding for `x` — codegen should reject cleanly.
+        let err = jit_i32("x").unwrap_err();
+        assert!(
+            err.contains("undefined variable"),
+            "expected undefined variable error, got: {}",
+            err
+        );
+    }
+
     #[test]
     fn jit_unsupported_node_is_error_not_panic() {
-        // Anything outside Step 5's scope must return Err so that the
+        // Anything outside Step 6's scope must return Err so that the
         // future `--llvm` REPL surfaces a clean message instead of crashing.
-        // `let-in` lands in Step 6, so it's still unsupported.
-        let err = jit_i32("(let x 1 x)").unwrap_err();
+        // String literals don't have a JIT representation yet.
+        let err = jit_i32(r#""hello""#).unwrap_err();
         assert!(
             err.contains("not supported"),
             "expected unsupported error, got: {}",

--- a/src/tests/codegen_tests.rs
+++ b/src/tests/codegen_tests.rs
@@ -361,6 +361,148 @@ mod tests {
         );
     }
 
+    // ----------- Step 7: defn + Call + recursion -----------
+
+    /// Helper: parse a multi-form program by repeatedly calling
+    /// `parse_expr` and consuming each top-level S-expression. Each
+    /// form is then handed to `jit_eval_*_program`.
+    fn parse_program(input: &str) -> Vec<crate::ast::Expr> {
+        use crate::parser::expr::parse_expr;
+        let mut forms = Vec::new();
+        let mut rest = input.trim();
+        while !rest.is_empty() {
+            let (remaining, expr) = parse_expr(rest).expect("parse_program parse");
+            forms.push(expr);
+            rest = remaining.trim();
+        }
+        forms
+    }
+
+    fn jit_i32_prog(input: &str) -> Result<i32, String> {
+        let forms = parse_program(input);
+        codegen::jit_eval_i32_program(&forms)
+    }
+
+    fn jit_bool_prog(input: &str) -> Result<bool, String> {
+        let forms = parse_program(input);
+        codegen::jit_eval_bool_program(&forms)
+    }
+
+    fn jit_f64_prog(input: &str) -> Result<f64, String> {
+        let forms = parse_program(input);
+        codegen::jit_eval_f64_program(&forms)
+    }
+
+    #[test]
+    fn jit_defn_simple_call() {
+        let src = r#"
+            (defn double [x: i32] -> i32 (* x 2))
+            (double 21)
+        "#;
+        assert_eq!(jit_i32_prog(src).unwrap(), 42);
+    }
+
+    #[test]
+    fn jit_defn_two_params() {
+        let src = r#"
+            (defn add [a: i32 b: i32] -> i32 (+ a b))
+            (add 3 4)
+        "#;
+        assert_eq!(jit_i32_prog(src).unwrap(), 7);
+    }
+
+    #[test]
+    fn jit_defn_returns_bool() {
+        let src = r#"
+            (defn is-pos [x: i32] -> bool (> x 0))
+            (is-pos 5)
+        "#;
+        assert!(jit_bool_prog(src).unwrap());
+        let src2 = r#"
+            (defn is-pos [x: i32] -> bool (> x 0))
+            (is-pos -3)
+        "#;
+        assert!(!jit_bool_prog(src2).unwrap());
+    }
+
+    #[test]
+    fn jit_defn_returns_f64() {
+        let src = r#"
+            (defn area [r: f64] -> f64 (*. r r))
+            (area 3.0)
+        "#;
+        assert_eq!(jit_f64_prog(src).unwrap(), 9.0);
+    }
+
+    #[test]
+    fn jit_defn_recursion_factorial() {
+        // The classic test: a recursive function whose body calls itself.
+        // The function value must be registered before the body is emitted.
+        let src = r#"
+            (defn fact [n: i32] -> i32
+              (if (<= n 1) 1 (* n (fact (- n 1)))))
+            (fact 5)
+        "#;
+        assert_eq!(jit_i32_prog(src).unwrap(), 120);
+    }
+
+    #[test]
+    fn jit_defn_recursion_fib() {
+        let src = r#"
+            (defn fib [n: i32] -> i32
+              (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
+            (fib 10)
+        "#;
+        assert_eq!(jit_i32_prog(src).unwrap(), 55);
+    }
+
+    #[test]
+    fn jit_defn_multiple() {
+        let src = r#"
+            (defn double [x: i32] -> i32 (* x 2))
+            (defn quad [x: i32] -> i32 (double (double x)))
+            (quad 5)
+        "#;
+        assert_eq!(jit_i32_prog(src).unwrap(), 20);
+    }
+
+    #[test]
+    fn jit_defn_with_let_in_body() {
+        let src = r#"
+            (defn sum-sq [a: i32 b: i32] -> i32
+              (let aa (* a a)
+                (let bb (* b b)
+                  (+ aa bb))))
+            (sum-sq 3 4)
+        "#;
+        assert_eq!(jit_i32_prog(src).unwrap(), 25);
+    }
+
+    #[test]
+    fn jit_call_undefined_function_errors() {
+        // No defn for `nope`; the call should surface a clean error.
+        let err = jit_i32_prog("(nope 1 2)").unwrap_err();
+        assert!(
+            err.contains("undefined function") || err.contains("nope"),
+            "expected undefined-function error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn jit_call_wrong_arity_errors() {
+        let src = r#"
+            (defn id [x: i32] -> i32 x)
+            (id 1 2)
+        "#;
+        let err = jit_i32_prog(src).unwrap_err();
+        assert!(
+            err.contains("expects") && err.contains("arguments"),
+            "expected arity error, got: {}",
+            err
+        );
+    }
+
     #[test]
     fn jit_unsupported_node_is_error_not_panic() {
         // Anything outside Step 6's scope must return Err so that the

--- a/src/tests/codegen_tests.rs
+++ b/src/tests/codegen_tests.rs
@@ -584,4 +584,67 @@ mod tests {
             err
         );
     }
+
+    // -------- Step 10: AOT (compile_to_ll) --------
+
+    #[test]
+    fn aot_emits_ll_with_defns_and_main() {
+        let src = r#"
+            (defn sq [n: i32] -> i32 (* n n))
+            (defn main [] -> i32 (sq 6))
+        "#;
+        let forms = parse_program(src);
+        let ir = codegen::compile_to_ll(&forms).unwrap();
+        // Both functions should appear in the textual IR.
+        assert!(ir.contains("define i32 @sq("), "missing sq: {}", ir);
+        assert!(ir.contains("define i32 @main("), "missing main: {}", ir);
+        // sq should be called from main.
+        assert!(ir.contains("call i32 @sq"), "missing call to sq: {}", ir);
+    }
+
+    #[test]
+    fn aot_rejects_program_without_main() {
+        let forms = parse_program("(defn sq [n: i32] -> i32 (* n n))");
+        let err = codegen::compile_to_ll(&forms).unwrap_err();
+        assert!(
+            err.contains("must be named `main`"),
+            "expected main-required error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn aot_rejects_main_with_wrong_return_type() {
+        let forms = parse_program("(defn main [] -> bool true)");
+        let err = codegen::compile_to_ll(&forms).unwrap_err();
+        assert!(
+            err.contains("must return `i32`"),
+            "expected return-type error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn aot_rejects_main_with_params() {
+        let forms = parse_program("(defn main [x: i32] -> i32 x)");
+        let err = codegen::compile_to_ll(&forms).unwrap_err();
+        assert!(
+            err.contains("zero parameters"),
+            "expected zero-params error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn aot_rejects_non_defn_form() {
+        // A trailing expression is rejected by AOT mode, even if it
+        // would type-check fine.
+        let forms = parse_program("(defn main [] -> i32 0) 42");
+        let err = codegen::compile_to_ll(&forms).unwrap_err();
+        assert!(
+            err.contains("not a `defn`") || err.contains("must be named `main`"),
+            "expected defn-only error, got: {}",
+            err
+        );
+    }
 }

--- a/src/tests/codegen_tests.rs
+++ b/src/tests/codegen_tests.rs
@@ -1,0 +1,84 @@
+#[cfg(test)]
+mod tests {
+    use crate::codegen;
+    use crate::parser;
+
+    #[test]
+    fn smoke_module_emits_module_header() {
+        // Step 1: prove that inkwell + LLVM toolchain are linked correctly.
+        // The IR for an empty module still includes the `; ModuleID = ...`
+        // header and a `source_filename` line, so non-empty is enough here.
+        let ir = codegen::smoke_module();
+        assert!(!ir.is_empty(), "expected non-empty IR, got empty string");
+        assert!(
+            ir.contains("rusp_smoke"),
+            "expected module name in IR, got: {}",
+            ir
+        );
+    }
+
+    /// Helper: parse `input` and JIT-run it as i32. Each call gets a fresh
+    /// Context (created inside `jit_eval_i32`), so tests are isolated.
+    fn jit_i32(input: &str) -> Result<i32, String> {
+        let ast = parser::parse(input).map_err(|e| e.to_string())?;
+        codegen::jit_eval_i32(&ast)
+    }
+
+    #[test]
+    fn jit_integer_literal() {
+        assert_eq!(jit_i32("42").unwrap(), 42);
+        assert_eq!(jit_i32("-7").unwrap(), -7);
+        assert_eq!(jit_i32("0").unwrap(), 0);
+    }
+
+    #[test]
+    fn jit_i32_addition() {
+        assert_eq!(jit_i32("(+ 1 2)").unwrap(), 3);
+        assert_eq!(jit_i32("(+ 100 -50)").unwrap(), 50);
+    }
+
+    #[test]
+    fn jit_i32_subtraction() {
+        assert_eq!(jit_i32("(- 10 4)").unwrap(), 6);
+        assert_eq!(jit_i32("(- 0 5)").unwrap(), -5);
+    }
+
+    #[test]
+    fn jit_i32_multiplication() {
+        assert_eq!(jit_i32("(* 6 7)").unwrap(), 42);
+        assert_eq!(jit_i32("(* -3 4)").unwrap(), -12);
+    }
+
+    #[test]
+    fn jit_i32_division() {
+        assert_eq!(jit_i32("(/ 20 4)").unwrap(), 5);
+        // Signed division — round toward zero.
+        assert_eq!(jit_i32("(/ -20 3)").unwrap(), -6);
+    }
+
+    #[test]
+    fn jit_i32_nested_arithmetic() {
+        // Both `Expr::List` (operator-headed) and arithmetic recursion exercised.
+        assert_eq!(jit_i32("(* (+ 1 2) 3)").unwrap(), 9);
+        assert_eq!(jit_i32("(+ (* 2 3) (- 10 4))").unwrap(), 12);
+    }
+
+    #[test]
+    fn jit_i32_variadic_left_fold() {
+        // `(+ a b c)` is left-folded to `((a + b) + c)`.
+        assert_eq!(jit_i32("(+ 1 2 3 4)").unwrap(), 10);
+        assert_eq!(jit_i32("(- 100 10 20 30)").unwrap(), 40);
+    }
+
+    #[test]
+    fn jit_unsupported_node_is_error_not_panic() {
+        // Anything outside Step 2's scope must return Err so that the
+        // future `--llvm` REPL surfaces a clean message instead of crashing.
+        let err = jit_i32("(if true 1 0)").unwrap_err();
+        assert!(
+            err.contains("not supported"),
+            "expected unsupported error, got: {}",
+            err
+        );
+    }
+}

--- a/src/tests/codegen_tests.rs
+++ b/src/tests/codegen_tests.rs
@@ -133,11 +133,106 @@ mod tests {
         );
     }
 
+    // ----------- Step 4: bool, comparison, if, and/or/not -----------
+
+    fn jit_bool(input: &str) -> Result<bool, String> {
+        let ast = parser::parse(input).map_err(|e| e.to_string())?;
+        codegen::jit_eval_bool(&ast)
+    }
+
+    #[test]
+    fn jit_bool_literal() {
+        assert!(jit_bool("true").unwrap());
+        assert!(!jit_bool("false").unwrap());
+    }
+
+    #[test]
+    fn jit_i32_comparison() {
+        assert!(jit_bool("(= 1 1)").unwrap());
+        assert!(!jit_bool("(= 1 2)").unwrap());
+        assert!(jit_bool("(< 1 2)").unwrap());
+        assert!(!jit_bool("(< 2 1)").unwrap());
+        assert!(jit_bool("(> 5 3)").unwrap());
+        assert!(jit_bool("(<= 3 3)").unwrap());
+        assert!(jit_bool("(>= 4 3)").unwrap());
+        // Negative numbers (signed comparison).
+        assert!(jit_bool("(< -5 0)").unwrap());
+    }
+
+    #[test]
+    fn jit_i64_comparison() {
+        // Operands are both > i32::MAX so the parser tags them as i64,
+        // exercising the SLT codegen path on i64.
+        assert!(jit_bool("(< 3000000000 4000000000)").unwrap());
+        assert!(!jit_bool("(= 3000000000 4000000000)").unwrap());
+    }
+
+    #[test]
+    fn jit_if_simple() {
+        assert_eq!(jit_i32("(if true 10 20)").unwrap(), 10);
+        assert_eq!(jit_i32("(if false 10 20)").unwrap(), 20);
+        // Condition that is itself a comparison.
+        assert_eq!(jit_i32("(if (= 1 1) 10 20)").unwrap(), 10);
+        assert_eq!(jit_i32("(if (< 5 1) 10 20)").unwrap(), 20);
+    }
+
+    #[test]
+    fn jit_if_nested() {
+        // Nested if exercises that emit_if captures the *end* block of
+        // each arm, not the start, so phi sources stay correct.
+        let src = "(if (< 0 1) (if (< 1 2) 1 2) 3)";
+        assert_eq!(jit_i32(src).unwrap(), 1);
+        let src2 = "(if (< 0 1) (if (> 1 2) 1 2) 3)";
+        assert_eq!(jit_i32(src2).unwrap(), 2);
+    }
+
+    #[test]
+    fn jit_if_returning_bool() {
+        // The merge phi should be i1 here.
+        assert!(jit_bool("(if true (= 1 1) (= 1 2))").unwrap());
+        assert!(!jit_bool("(if false (= 1 1) (= 1 2))").unwrap());
+    }
+
+    #[test]
+    fn jit_and_basic() {
+        assert!(jit_bool("(and true true)").unwrap());
+        assert!(!jit_bool("(and true false)").unwrap());
+        assert!(!jit_bool("(and false true)").unwrap());
+        assert!(!jit_bool("(and false false)").unwrap());
+        // Variadic and: left-fold.
+        assert!(jit_bool("(and true true true)").unwrap());
+        assert!(!jit_bool("(and true true false)").unwrap());
+    }
+
+    #[test]
+    fn jit_or_basic() {
+        assert!(jit_bool("(or true false)").unwrap());
+        assert!(jit_bool("(or false true)").unwrap());
+        assert!(!jit_bool("(or false false)").unwrap());
+        assert!(jit_bool("(or false false true)").unwrap());
+    }
+
+    #[test]
+    fn jit_not_basic() {
+        assert!(!jit_bool("(not true)").unwrap());
+        assert!(jit_bool("(not false)").unwrap());
+        assert!(jit_bool("(not (= 1 2))").unwrap());
+    }
+
+    #[test]
+    fn jit_logical_with_comparison() {
+        // Compose comparisons + logical ops in one expression.
+        assert!(jit_bool("(and (< 1 2) (> 3 1))").unwrap());
+        assert!(jit_bool("(or (= 1 2) (< 1 2))").unwrap());
+        assert!(jit_bool("(not (and (< 1 2) (> 1 3)))").unwrap());
+    }
+
     #[test]
     fn jit_unsupported_node_is_error_not_panic() {
-        // Anything outside Step 2's scope must return Err so that the
+        // Anything outside Step 4's scope must return Err so that the
         // future `--llvm` REPL surfaces a clean message instead of crashing.
-        let err = jit_i32("(if true 1 0)").unwrap_err();
+        // `let-in` lands in Step 6, so it's still unsupported.
+        let err = jit_i32("(let x 1 x)").unwrap_err();
         assert!(
             err.contains("not supported"),
             "expected unsupported error, got: {}",

--- a/src/tests/codegen_tests.rs
+++ b/src/tests/codegen_tests.rs
@@ -24,6 +24,11 @@ mod tests {
         codegen::jit_eval_i32(&ast)
     }
 
+    fn jit_i64(input: &str) -> Result<i64, String> {
+        let ast = parser::parse(input).map_err(|e| e.to_string())?;
+        codegen::jit_eval_i64(&ast)
+    }
+
     #[test]
     fn jit_integer_literal() {
         assert_eq!(jit_i32("42").unwrap(), 42);
@@ -68,6 +73,64 @@ mod tests {
         // `(+ a b c)` is left-folded to `((a + b) + c)`.
         assert_eq!(jit_i32("(+ 1 2 3 4)").unwrap(), 10);
         assert_eq!(jit_i32("(- 100 10 20 30)").unwrap(), 40);
+    }
+
+    // ----------- Step 3: i64 arithmetic -----------
+
+    #[test]
+    fn jit_i64_literal() {
+        // The parser picks i64 once a literal exceeds i32::MAX, so this
+        // also exercises the parser → codegen handoff for i64.
+        assert_eq!(
+            jit_i64("9223372036854775807").unwrap(),
+            i64::MAX
+        );
+    }
+
+    #[test]
+    fn jit_i64_addition() {
+        // Both operands are outside i32 range, so the parser tags them as i64.
+        // (Mixing i32 and i64 in one form is rejected by the type checker
+        // and would also surface as a width-mismatch error here.)
+        assert_eq!(
+            jit_i64("(+ 100000000000 1000000000000)").unwrap(),
+            1_100_000_000_000
+        );
+    }
+
+    #[test]
+    fn jit_i64_full_arithmetic() {
+        // Each operand must individually exceed i32::MAX so the parser
+        // tags it as i64. (Rusp has no `5_i64` suffix syntax yet —
+        // separating those concerns is outside the LLVM-MVP scope.)
+        assert_eq!(
+            jit_i64("(- 5000000000 4000000000)").unwrap(),
+            1_000_000_000
+        );
+        // Both factors > i32::MAX (~2.1e9), product fits comfortably in i64.
+        assert_eq!(
+            jit_i64("(* 3000000000 2500000000)").unwrap(),
+            7_500_000_000_000_000_000
+        );
+        assert_eq!(
+            jit_i64("(/ 9000000000 3000000000)").unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn jit_width_mismatch_is_caught() {
+        // Asking for i32 when the body produced i64 surfaces a clean
+        // error rather than silently truncating bits.
+        let err = codegen::jit_eval_i32(
+            &parser::parse("100000000000").unwrap()
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("requested i32") && err.contains("produced i64"),
+            "expected width mismatch error, got: {}",
+            err
+        );
     }
 
     #[test]

--- a/src/tests/codegen_tests.rs
+++ b/src/tests/codegen_tests.rs
@@ -227,9 +227,72 @@ mod tests {
         assert!(jit_bool("(not (and (< 1 2) (> 1 3)))").unwrap());
     }
 
+    // ----------- Step 5: f64 arithmetic and comparison -----------
+
+    fn jit_f64(input: &str) -> Result<f64, String> {
+        let ast = parser::parse(input).map_err(|e| e.to_string())?;
+        codegen::jit_eval_f64(&ast)
+    }
+
+    #[test]
+    fn jit_f64_literal() {
+        assert_eq!(jit_f64("1.5").unwrap(), 1.5);
+        assert_eq!(jit_f64("0.0").unwrap(), 0.0);
+        assert_eq!(jit_f64("-2.25").unwrap(), -2.25);
+    }
+
+    #[test]
+    fn jit_f64_arithmetic() {
+        assert_eq!(jit_f64("(+. 1.5 2.5)").unwrap(), 4.0);
+        assert_eq!(jit_f64("(-. 5.0 1.5)").unwrap(), 3.5);
+        assert_eq!(jit_f64("(*. 2.0 3.5)").unwrap(), 7.0);
+        assert_eq!(jit_f64("(/. 7.0 2.0)").unwrap(), 3.5);
+    }
+
+    #[test]
+    fn jit_f64_variadic_left_fold() {
+        assert_eq!(jit_f64("(+. 1.0 2.0 3.0 4.0)").unwrap(), 10.0);
+        assert_eq!(jit_f64("(*. 2.0 3.0 4.0)").unwrap(), 24.0);
+    }
+
+    #[test]
+    fn jit_f64_nested() {
+        assert_eq!(jit_f64("(*. (+. 1.0 2.0) 3.0)").unwrap(), 9.0);
+        assert_eq!(jit_f64("(+. (*. 2.0 3.0) (-. 10.0 4.0))").unwrap(), 12.0);
+    }
+
+    #[test]
+    fn jit_f64_comparison() {
+        assert!(jit_bool("(= 1.5 1.5)").unwrap());
+        assert!(!jit_bool("(= 1.5 2.5)").unwrap());
+        assert!(jit_bool("(< 1.5 2.5)").unwrap());
+        assert!(!jit_bool("(< 2.5 1.5)").unwrap());
+        assert!(jit_bool("(> 3.0 1.0)").unwrap());
+        assert!(jit_bool("(<= 1.5 1.5)").unwrap());
+        assert!(jit_bool("(>= 2.0 1.0)").unwrap());
+    }
+
+    #[test]
+    fn jit_f64_with_if() {
+        // `if` returning f64 — phi merge on f64 type.
+        assert_eq!(jit_f64("(if true 1.5 2.5)").unwrap(), 1.5);
+        assert_eq!(jit_f64("(if false 1.5 2.5)").unwrap(), 2.5);
+        // Condition uses float comparison.
+        assert_eq!(jit_f64("(if (< 1.5 2.0) 10.0 20.0)").unwrap(), 10.0);
+    }
+
+    #[test]
+    fn jit_int_op_on_float_is_error() {
+        // `+` on floats is rejected by the type checker, but the codegen
+        // path also rejects it defensively.
+        let err = jit_f64("(+ 1.0 2.0)").unwrap_err();
+        // The type checker fires first ("expected i32" or similar).
+        assert!(!err.is_empty());
+    }
+
     #[test]
     fn jit_unsupported_node_is_error_not_panic() {
-        // Anything outside Step 4's scope must return Err so that the
+        // Anything outside Step 5's scope must return Err so that the
         // future `--llvm` REPL surfaces a clean message instead of crashing.
         // `let-in` lands in Step 6, so it's still unsupported.
         let err = jit_i32("(let x 1 x)").unwrap_err();

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,2 +1,3 @@
-mod parser_tests;
+mod codegen_tests;
 mod eval_tests;
+mod parser_tests;

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,6 +11,12 @@ pub struct TypeEnv {
     pub refinements: HashMap<String, Type>,
 }
 
+impl Default for TypeEnv {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TypeEnv {
     pub fn new() -> Self {
         let mut types = HashMap::new();


### PR DESCRIPTION
## Summary

LLVM 18 / inkwell 0.9 バックエンドを段階的に追加。MVPスコープは **スカラ型 + 関数 + 再帰**。`List` / `match` / `String` は対象外（将来追加）。

- **JIT**: `cargo run -- --llvm` でREPL内JIT実行
- **AOT**: `cargo run -- build FILE --emit ll|obj` で LLVM IR / ネイティブオブジェクトを生成
- 共有コード生成: `emit_defn` を JIT/AOT で共用、`EmitVal` (`Int` / `Float` / `FuncRef`) で SSA値の種別を区別、`FuncRef` は境界で拒否

## Steps (10 commits)

| # | Step | 概要 |
|---|------|------|
| 1 | bootstrap | inkwell + LLVM 18 リンク、i32 JIT スモーク |
| 3 | i64 | i64 算術 |
| 4 | bool/cmp/if | 比較・`if` (phi-merge)・`and`/`or`/`not` (short-circuit) |
| 5 | f64 | f64 算術と ordered 比較 |
| 6 | let-in | 字句スコープ束縛 (SSA、parent-chain なし) |
| 7 | defn | 関数定義 + Call + 直接再帰 |
| 8 | lambda | キャプチャ無し `(fn [...] -> T body)` (`FuncRef` 経由で `let` を流れる) |
| 9 | `--llvm` REPL | JIT モードでの REPL。`defn` は再エミットバッファに蓄積 |
| 10 | AOT | `(defn main [] -> i32 ...)` を C-ABI エントリとして emit |
| 11 | docs | README + CLAUDE.md |

## Verification

- `cargo test`: **199 passed** (191 lib + 8 doc)
- `cargo clippy --all-targets -- -D warnings`: clean
- E2E: `(defn sq [n: i32] -> i32 (* n n)) (defn main [] -> i32 (sq 6))` → `cc out.o` → `./hello; echo \$?` → `36`

## Out of scope (将来)

- `List` / `cons` / `nil` / `match` の codegen
- `String` の境界表現
- ラムダの自由変数キャプチャ
- ラムダ戻り型推論

## Test plan

- [x] `nix develop --command cargo test` が全通り
- [x] `nix develop --command cargo clippy --all-targets -- -D warnings` がクリーン
- [x] `cargo run` 通常 REPL で従来挙動が変わっていない
- [x] `cargo run -- --llvm` で `(defn sq [n: i32] -> i32 (* n n)) (sq 7)` が `49: i32`
- [x] `cargo run -- build FILE --emit ll` で `.ll` が生成される
- [x] `cargo run -- build FILE --emit obj && cc FILE.o -o exe && ./exe; echo \$?` が `main` の戻り値を返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)
